### PR TITLE
Shutdown jvm before directory is removed

### DIFF
--- a/optapy-core/src/main/java/org/optaplanner/optapy/PythonWrapperGenerator.java
+++ b/optapy-core/src/main/java/org/optaplanner/optapy/PythonWrapperGenerator.java
@@ -134,6 +134,18 @@ public class PythonWrapperGenerator {
         return Array.newInstance(elementClass, 0).getClass();
     }
 
+    // Used in Python to exit the JVM.
+    // There an issue in Windows where if the JVM
+    // is not terminated, a file in use error occurs
+    // when removing the temporary directories
+    // that contain the dependency jars.
+    //
+    // TODO: Remove when https://github.com/jpype-project/jpype/issues/1006 is fixed
+    @SuppressWarnings("unused")
+    public static void shutdownJVM() {
+        System.exit(0);
+    }
+
     // Holds the OpaquePythonReference
     static final String pythonBindingFieldName = "__optaplannerPythonValue";
 
@@ -179,9 +191,8 @@ public class PythonWrapperGenerator {
      *
      * {@code 
      * 
-     * 
-    
-    <pre>
+     *
+     * <pre>
      * class PythonConstraintProvider implements ConstraintProvider {
      *     public static Function<ConstraintFactory, Constraint[]> defineConstraintsImpl;
      *

--- a/optapy-core/src/main/python/optaplanner_java_interop.py
+++ b/optapy-core/src/main/python/optaplanner_java_interop.py
@@ -154,7 +154,8 @@ def _shutdown_jvm_if_still_running():
     Windows.
     """
     if jpype.isJVMStarted():
-        jpype.shutdownJVM()
+        from org.optaplanner.optapy import PythonWrapperGenerator
+        PythonWrapperGenerator.shutdownJVM()
 
 
 def init(*args, path=None, include_optaplanner_jars=True, log_level='INFO'):


### PR DESCRIPTION
JPype has an issue on Python exit in Windows when temporary directories are used: https://github.com/jpype-project/jpype/issues/1006 ; this uses a workaround to close the JVM before Python exit. 