### PR TITLE
Add atexit handler to force JVM to terminate

### DIFF
--- a/optapy-core/tests/test_setup.py
+++ b/optapy-core/tests/test_setup.py
@@ -1,0 +1,18 @@
+import atexit
+import jpype.imports
+import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_jvm(request):
+    # Will be executed before the first test
+    yield None
+    # Will be executed after the last test
+    from java.lang import Runtime
+    exit_status = 0 if request.session.testsfailed == 0 else 1
+    atexit.register(lambda: Runtime.getRuntime().halt(exit_status))
+
+
+def test_setup(setup_jvm):
+    # required so teardown is executed
+    pass

--- a/optapy-core/tests/test_solver_manager.py
+++ b/optapy-core/tests/test_solver_manager.py
@@ -1,19 +1,8 @@
-import pytest
 import optapy
 import optapy.types
 import optapy.score
 import optapy.config
 import optapy.constraint
-
-
-@pytest.fixture(scope='session', autouse=True)
-def setup_jvm():
-    # Will be executed before the first test
-    yield None
-    # Will be executed after the last test
-    import jpype
-    jpype.shutdownJVM()
-
 
 
 def test_solve():
@@ -217,4 +206,3 @@ def test_solve():
         assert_problem_change_solver_run(solver_manager, solver_job)
         assert len(solution_list) == 3
     time.sleep(1)  # ensure the thread factory close
-


### PR DESCRIPTION
It appears some threads in the FixedThreadPoolExecutor are not
stopped, but rather wait on a lock, forever. This leads to
Pytest not terminating as it requires all threads to be stopped.