### PR TITLE
Add solver_config_create_from_xml_file function

### DIFF
--- a/optapy-core/src/main/java/org/optaplanner/optapy/PythonWrapperGenerator.java
+++ b/optapy-core/src/main/java/org/optaplanner/optapy/PythonWrapperGenerator.java
@@ -55,7 +55,7 @@ public class PythonWrapperGenerator {
     static ClassLoader gizmoClassLoader = new ClassLoader() {
         // getName() is an abstract method in Java 11 but not in Java 8
         public String getName() {
-            return "OptaPlanner Gizmo Python Wrapper ClassLoader";
+            return "OptaPy Generated Classes ClassLoader";
         }
 
         @Override
@@ -146,6 +146,27 @@ public class PythonWrapperGenerator {
     @SuppressWarnings("unused")
     public static OpaquePythonReference getPythonObject(PythonObject pythonObject) {
         return pythonObject.get__optapy_Id();
+    }
+
+    @SuppressWarnings("unused")
+    public static ClassLoader getClassLoaderForAliasMap(Map<String, Class<?>> aliasMap) {
+        return new ClassLoader() {
+            // getName() is an abstract method in Java 11 but not in Java 8
+            public String getName() {
+                return "OptaPy Alias Map ClassLoader";
+            }
+
+            @Override
+            public Class<?> findClass(String name) throws ClassNotFoundException {
+                if (aliasMap.containsKey(name)) {
+                    // Gizmo generated class
+                    return aliasMap.get(name);
+                } else {
+                    // Not a Gizmo generated class; load from parent class loader
+                    return gizmoClassLoader.loadClass(name);
+                }
+            }
+        };
     }
 
     @SuppressWarnings("unused")

--- a/optapy-core/src/main/python/optaplanner_api_wrappers.py
+++ b/optapy-core/src/main/python/optaplanner_api_wrappers.py
@@ -253,21 +253,25 @@ class _PythonProblemChangeDirector:
         self._java_removeProblemFact(_wrap_object(problemFact, instance_map), problemFactConsumer)
 
 
-def solver_config_create_from_xml_file(path: pathlib.Path) -> '_SolverConfig':
+def solver_config_create_from_xml_file(solver_config_path: pathlib.Path) -> '_SolverConfig':
     """Loads a SolverConfig from the given file.
 
-    :param path: The path to the file
+    :param solver_config_path: The path to the file
     :return: A new SolverConfig generated from the file at path
     """
-    from java.lang import Thread
+    from java.lang import Thread, IllegalArgumentException
     from org.optaplanner.optapy import PythonWrapperGenerator  # noqa
     from org.optaplanner.core.config.solver import SolverConfig
     class_loader = PythonWrapperGenerator.getClassLoaderForAliasMap(_class_identifier_to_java_class_map)
     current_thread = Thread.currentThread()
     thread_class_loader = current_thread.getContextClassLoader()
-    current_thread.setContextClassLoader(class_loader)
-    solver_config = SolverConfig.createFromXmlFile(path)
-    current_thread.setContextClassLoader(thread_class_loader)
+    try:
+        current_thread.setContextClassLoader(class_loader)
+        solver_config = SolverConfig.createFromXmlFile(solver_config_path)
+    except IllegalArgumentException as e:
+        raise FileNotFoundError(f'Unable to find SolverConfig file ({solver_config_path}).') from e
+    finally:
+        current_thread.setContextClassLoader(thread_class_loader)
     return solver_config
 
 

--- a/optapy-core/tests/solverConfig-redefined.xml
+++ b/optapy-core/tests/solverConfig-redefined.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
+  <solutionClass>tests.test_solver_config.RedefinedSolution</solutionClass>
+</solver>

--- a/optapy-core/tests/solverConfig-simple.xml
+++ b/optapy-core/tests/solverConfig-simple.xml
@@ -11,18 +11,4 @@
   <termination>
     <bestScoreLimit>0hard/0soft</bestScoreLimit>
   </termination>
-  <constructionHeuristic>
-    <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>
-  </constructionHeuristic>
-  <localSearch>
-    <changeMoveSelector>
-      <selectionOrder>ORIGINAL</selectionOrder>
-    </changeMoveSelector>
-    <acceptor>
-      <entityTabuSize>5</entityTabuSize>
-    </acceptor>
-    <forager>
-      <!-- Real world problems require use of <acceptedCountLimit> -->
-    </forager>
-  </localSearch>
 </solver>

--- a/optapy-core/tests/solverConfig-simple.xml
+++ b/optapy-core/tests/solverConfig-simple.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver xmlns="https://www.optaplanner.org/xsd/solver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.optaplanner.org/xsd/solver https://www.optaplanner.org/xsd/solver/solver.xsd">
+  <solutionClass>tests.test_solver_config.Solution</solutionClass>
+  <entityClass>tests.test_solver_config.Entity</entityClass>
+
+  <scoreDirectorFactory>
+    <constraintProviderClass>tests.test_solver_config.my_constraints</constraintProviderClass>
+  </scoreDirectorFactory>
+
+  <termination>
+    <bestScoreLimit>0hard/0soft</bestScoreLimit>
+  </termination>
+  <constructionHeuristic>
+    <constructionHeuristicType>FIRST_FIT</constructionHeuristicType>
+  </constructionHeuristic>
+  <localSearch>
+    <changeMoveSelector>
+      <selectionOrder>ORIGINAL</selectionOrder>
+    </changeMoveSelector>
+    <acceptor>
+      <entityTabuSize>5</entityTabuSize>
+    </acceptor>
+    <forager>
+      <!-- Real world problems require use of <acceptedCountLimit> -->
+    </forager>
+  </localSearch>
+</solver>

--- a/optapy-core/tests/test_solver_config.py
+++ b/optapy-core/tests/test_solver_config.py
@@ -71,6 +71,7 @@ def test_load_from_solver_config_file():
     assert entity_class_list.get(0) == optapy.get_class(Entity)
     assert solver_config.getScoreDirectorFactoryConfig().getConstraintProviderClass() == \
            optapy.get_class(my_constraints)
+    assert solver_config.getTerminationConfig().getBestScoreLimit() == '0hard/0soft'
 
 
 def test_reload_from_solver_config_file():

--- a/optapy-core/tests/test_solver_config.py
+++ b/optapy-core/tests/test_solver_config.py
@@ -1,4 +1,6 @@
 import pathlib
+import pytest
+import re
 import optapy
 import optapy.score
 import optapy.config
@@ -88,3 +90,12 @@ def test_reload_from_solver_config_file():
 
     assert solver_config_1.getSolutionClass() == optapy.get_class(RedefinedSolution1)
     assert solver_config_2.getSolutionClass() == optapy.get_class(RedefinedSolution2)
+
+
+def test_cannot_find_solver_config_file():
+    from java.lang import Thread
+    current_thread = Thread.currentThread()
+    thread_class_loader = current_thread.getContextClassLoader()
+    with pytest.raises(FileNotFoundError, match=re.escape("Unable to find SolverConfig file (does-not-exist.xml).")):
+        optapy.solver_config_create_from_xml_file(pathlib.Path('does-not-exist.xml'))
+    assert current_thread.getContextClassLoader() == thread_class_loader

--- a/optapy-core/tests/test_solver_config.py
+++ b/optapy-core/tests/test_solver_config.py
@@ -1,0 +1,90 @@
+import pathlib
+import optapy
+import optapy.score
+import optapy.config
+import optapy.constraint
+
+@optapy.planning_entity
+class Entity:
+    def __init__(self, code, value=None):
+        self.code = code
+        self.value = value
+
+    @optapy.planning_variable(str, value_range_provider_refs=['value_range'])
+    def get_value(self):
+        return self.value
+
+    def set_value(self, value):
+        self.value = value
+
+@optapy.problem_fact
+class Value:
+    def __init__(self, code):
+        self.code = code
+
+@optapy.constraint_provider
+def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
+    return [
+        constraint_factory.forEach(optapy.get_class(Entity))
+            .join(optapy.get_class(Value),
+                  [optapy.constraint.Joiners.equal(lambda entity: entity.value,
+                                                   lambda value: value.code)])
+            .reward('Same as value', optapy.score.SimpleScore.ONE),
+    ]
+
+@optapy.planning_solution
+class Solution:
+    def __init__(self, entity, value, value_range, score=None):
+        self.entity = entity
+        self.value = value
+        self.value_range = value_range
+        self.score = score
+
+    @optapy.planning_entity_property(Entity)
+    def get_entity(self):
+        return self.entity
+
+    @optapy.problem_fact_property(Value)
+    def get_value(self):
+        return self.value
+
+    @optapy.problem_fact_collection_property(str)
+    @optapy.value_range_provider(range_id='value_range')
+    def get_value_range(self):
+        return self.value_range
+
+    @optapy.planning_score(optapy.score.SimpleScore)
+    def get_score(self) -> optapy.score.SimpleScore:
+        return self.score
+
+    def set_score(self, score):
+        self.score = score
+
+
+def test_load_from_solver_config_file():
+    solver_config = optapy.solver_config_create_from_xml_file(pathlib.Path('tests', 'solverConfig-simple.xml'))
+    assert solver_config.getSolutionClass() == optapy.get_class(Solution)
+    entity_class_list = solver_config.getEntityClassList()
+    assert entity_class_list.size() == 1
+    assert entity_class_list.get(0) == optapy.get_class(Entity)
+    assert solver_config.getScoreDirectorFactoryConfig().getConstraintProviderClass() == \
+           optapy.get_class(my_constraints)
+
+
+def test_reload_from_solver_config_file():
+    @optapy.planning_solution
+    class RedefinedSolution:
+        ...
+
+    RedefinedSolution1 = RedefinedSolution
+    solver_config_1 = optapy.solver_config_create_from_xml_file(pathlib.Path('tests', 'solverConfig-redefined.xml'))
+
+    @optapy.planning_solution
+    class RedefinedSolution:
+        ...
+
+    RedefinedSolution2 = RedefinedSolution
+    solver_config_2 = optapy.solver_config_create_from_xml_file(pathlib.Path('tests', 'solverConfig-redefined.xml'))
+
+    assert solver_config_1.getSolutionClass() == optapy.get_class(RedefinedSolution1)
+    assert solver_config_2.getSolutionClass() == optapy.get_class(RedefinedSolution2)


### PR DESCRIPTION
The class name to use in *Class elements is the
module + class/function name. If the module is __main__,
then only the class name to be supplied. Example:

```python
from my.domain import MyEntity # my.domain.MyEntity

class MySolution: # MySolution
    ...

if __name__ == '__main__':
    solver_config =
    solver_config_create_from_xml_file(pathlib.Path('solverConfig.xml'))
```

The code works by creating a new ClassLoader from the current alias
map, which allows multiple classes with the same module + name to
exist, of which the latest defined is used (think notebooks and terminal).