### PR TITLE
Remove logback status message on start; add Python logging API

### DIFF
--- a/optapy-core/pom.xml
+++ b/optapy-core/pom.xml
@@ -37,7 +37,10 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/optapy-core/src/main/java/org/optaplanner/optapy/logging/PythonLogLevel.java
+++ b/optapy-core/src/main/java/org/optaplanner/optapy/logging/PythonLogLevel.java
@@ -1,0 +1,39 @@
+package org.optaplanner.optapy.logging;
+
+import ch.qos.logback.classic.Level;
+
+public enum PythonLogLevel {
+    CRITICAL(50, Level.ERROR),
+    ERROR(40, Level.ERROR),
+    WARNING(30, Level.WARN),
+    INFO(20, Level.INFO),
+    DEBUG(10, Level.DEBUG),
+    NOTSET(0, Level.INFO);
+
+    final int pythonLevelNumber;
+    final Level javaLogLevel;
+
+    PythonLogLevel(int pythonLevelNumber, Level javaLogLevel) {
+        this.pythonLevelNumber = pythonLevelNumber;
+        this.javaLogLevel = javaLogLevel;
+    }
+
+    public int getPythonLevelNumber() {
+        return pythonLevelNumber;
+    }
+
+    public Level getJavaLogLevel() {
+        return javaLogLevel;
+    }
+
+    public static PythonLogLevel fromPythonLevelNumber(int levelNumber) {
+        PythonLogLevel bestMatch = PythonLogLevel.CRITICAL;
+        int bestMatchLevelNumber = 50;
+        for (PythonLogLevel pythonLogLevel : PythonLogLevel.values()) {
+            if (pythonLogLevel.pythonLevelNumber >= levelNumber && pythonLogLevel.pythonLevelNumber < bestMatchLevelNumber) {
+                bestMatch = pythonLogLevel;
+            }
+        }
+        return bestMatch;
+    }
+}

--- a/optapy-core/src/main/java/org/optaplanner/optapy/logging/PythonLoggingToLogbackAdapter.java
+++ b/optapy-core/src/main/java/org/optaplanner/optapy/logging/PythonLoggingToLogbackAdapter.java
@@ -1,0 +1,32 @@
+package org.optaplanner.optapy.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import org.slf4j.LoggerFactory;
+
+public class PythonLoggingToLogbackAdapter {
+
+    private static Logger getLogger(String loggerName) {
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        return loggerContext.getLogger(loggerName);
+    }
+
+    public static void setLevel(String loggerName, int logLevel) {
+        Logger logger = getLogger(loggerName);
+        PythonLogLevel pythonLogLevel = PythonLogLevel.fromPythonLevelNumber(logLevel);
+        logger.setLevel(pythonLogLevel.getJavaLogLevel());
+    }
+
+    public static boolean isEnabledFor(String loggerName, int logLevel) {
+        Logger logger = getLogger(loggerName);
+        PythonLogLevel pythonLogLevel = PythonLogLevel.fromPythonLevelNumber(logLevel);
+        return logger.isEnabledFor(pythonLogLevel.getJavaLogLevel());
+    }
+
+    public static int getEffectiveLevel(String loggerName) {
+        Logger logger = getLogger(loggerName);
+        Level effectiveLogLevel = logger.getEffectiveLevel();
+        return effectiveLogLevel.levelInt / 1000;
+    }
+}

--- a/optapy-core/src/main/python/optaplanner_java_interop.py
+++ b/optapy-core/src/main/python/optaplanner_java_interop.py
@@ -8,6 +8,7 @@ import importlib.metadata
 from inspect import signature, Parameter
 from typing import cast, List, Tuple, Type, TypeVar, Callable, Dict, Any, Union, TYPE_CHECKING
 import copy
+from .optaplanner_python_logger import optapy_logger
 from .jpype_type_conversions import PythonSupplier, PythonFunction, PythonBiFunction, PythonTriFunction, \
     ConstraintProviderFunction
 

--- a/optapy-core/src/main/python/optaplanner_python_logger.py
+++ b/optapy-core/src/main/python/optaplanner_python_logger.py
@@ -1,0 +1,42 @@
+import logging
+
+__original_logging_class = logging.getLoggerClass()
+
+
+class OptaPyLogger(__original_logging_class):
+    def __init__(self, name):
+        super().__init__(name)
+        subpackage = name[len('optapy'):]
+        self.java_logger_name = f'org.optaplanner{subpackage}'
+
+    def setLevel(self, level):
+        from org.optaplanner.optapy.logging import PythonLoggingToLogbackAdapter
+        PythonLoggingToLogbackAdapter.setLevel(self.java_logger_name, level)
+
+    def isEnabledFor(self, level):
+        from org.optaplanner.optapy.logging import PythonLoggingToLogbackAdapter
+        PythonLoggingToLogbackAdapter.isEnabledFor(self.java_logger_name, level)
+
+    def getEffectiveLevel(self):
+        from org.optaplanner.optapy.logging import PythonLoggingToLogbackAdapter
+        PythonLoggingToLogbackAdapter.getEffectiveLevel(self.java_logger_name)
+
+    def getChild(self, suffix):
+        return OptaPyLogger(f'{self.name}.{suffix}')
+
+    def addFilter(self, filter):
+        raise NotImplementedError(f'Cannot add filter to {self.java_logger_name} logger')
+
+    def removeFilter(self, filter):
+        raise NotImplementedError(f'Cannot remove filter from {self.java_logger_name} logger')
+
+    def addHandler(self, hdlr):
+        raise NotImplementedError(f'Cannot add handler to {self.java_logger_name} logger')
+
+    def removeHandler(self, hdlr):
+        raise NotImplementedError(f'Cannot remove handler from {self.java_logger_name} logger')
+
+
+logging.setLoggerClass(OptaPyLogger)
+optapy_logger = logging.getLogger('optapy')
+logging.setLoggerClass(__original_logging_class)

--- a/optapy-core/src/main/resources/logback.xml
+++ b/optapy-core/src/main/resources/logback.xml
@@ -1,33 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
   <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <!-- %L lowers performance, %C and %c break indentation and therefore reduce readability, normal %t is verbose -->
       <pattern>%d{HH:mm:ss.SSS} [%-12.12t] %-5p %m%n</pattern>
     </encoder>
   </appender>
-  <!--<appender name="fileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">-->
-    <!--<file>local/log/optaplanner.log</file>-->
-    <!--<rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">-->
-      <!--<fileNamePattern>local/log/optaplanner.%i.log.zip</fileNamePattern>-->
-      <!--<minIndex>1</minIndex>-->
-      <!--<maxIndex>3</maxIndex>-->
-    <!--</rollingPolicy>-->
-    <!--<triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">-->
-      <!--<maxFileSize>5MB</maxFileSize>-->
-    <!--</triggeringPolicy>-->
-    <!--<encoder>-->
-      <!--<pattern>%d{HH:mm:ss.SSS} [%t] %-5p %m%n</pattern>-->
-    <!--</encoder>-->
-  <!--</appender>-->
 
-  <!-- To override the debug log level from the command line, use the VM option "-Dlogback.level.org.optaplanner=trace" -->
   <logger name="org.optaplanner" level="${logback.level.org.optaplanner:-info}"/>
 
   <root level="warn">
     <appender-ref ref="consoleAppender" />
-    <!--<appender-ref ref="fileAppender" />-->
   </root>
-
 </configuration>


### PR DESCRIPTION
Uses https://docs.python.org/3/library/logging.html for the Python
interface to the Java logger. Python does not have a TRACE level,
and has an level above ERROR, CRITICAL. To disable the logback
messages, a NO-OP Status Appender was used.