### PR TITLE
Add README for documentation module

### DIFF
--- a/optapy-docs/README.adoc
+++ b/optapy-docs/README.adoc
@@ -1,0 +1,6 @@
+= OptaPy Documentation
+
+View the documentation at https://www.optapy.org[the OptaPy documentation website].
+The documentation will not render correctly on GitHub.
+
+This module contains the sources for OptaPy's documentation website.


### PR DESCRIPTION
The documentation does not render correctly on GitHub,
so I added a README with a link to the documentation website
to redirect users there in case they go searching through the
optapy-docs directory.

Fixes #72 