### PR TITLE
Add dunder methods used by bytecode in proxies

### DIFF
--- a/optapy-core/src/main/java/org/optaplanner/optapy/PythonComparable.java
+++ b/optapy-core/src/main/java/org/optaplanner/optapy/PythonComparable.java
@@ -47,7 +47,7 @@ public class PythonComparable implements Comparable<PythonComparable> {
         return pythonObjectHash.apply(pythonObject);
     }
 
-    private final OpaquePythonReference reference;
+    public final OpaquePythonReference reference;
 
     public PythonComparable(OpaquePythonReference reference) {
         this.reference = reference;

--- a/optapy-core/src/main/java/org/optaplanner/optapy/PythonWrapperGenerator.java
+++ b/optapy-core/src/main/java/org/optaplanner/optapy/PythonWrapperGenerator.java
@@ -148,6 +148,10 @@ public class PythonWrapperGenerator {
         return pythonObject.get__optapy_Id();
     }
 
+    public static OpaquePythonReference getPythonObject(PythonComparable pythonObject) {
+        return pythonObject.reference;
+    }
+
     @SuppressWarnings("unused")
     public static ClassLoader getClassLoaderForAliasMap(Map<String, Class<?>> aliasMap) {
         return new ClassLoader() {

--- a/optapy-core/tests/test_domain.py
+++ b/optapy-core/tests/test_domain.py
@@ -110,6 +110,13 @@ def test_python_object():
             constraint_factory.forEach(optapy.get_class(Entity))
                 .groupBy(lambda entity: entity.value, optapy.constraint.ConstraintCollectors.count())
                 .reward('Entity have same value', optapy.score.SimpleScore.ONE, lambda value, count: count * count),
+            constraint_factory.forEach(optapy.get_class(Entity))
+                .groupBy(lambda entity: (entity.code, entity.value))
+                .join(optapy.get_class(Entity), [
+                    optapy.constraint.Joiners.equal(lambda pair: pair[0], lambda entity: entity.code),
+                    optapy.constraint.Joiners.equal(lambda pair: pair[1], lambda entity: entity.value)
+                ])
+                .reward('Entity for pair', optapy.score.SimpleScore.ONE),
         ]
 
     @optapy.planning_solution
@@ -149,7 +156,7 @@ def test_python_object():
     problem: Solution = Solution(Entity('A'), Value(date1), [date1, date2, date3])
     solver = optapy.solver_factory_create(solver_config).buildSolver()
     solution = solver.solve(problem)
-    assert solution.get_score().getScore() == 2
+    assert solution.get_score().getScore() == 3
     assert solution.entity.value == date1
 
 


### PR DESCRIPTION
For optimization reasons, the Python interpreter
check the types and ignore the object attributes
when looking for dunder methods. Additionally,
PythonComparable was not proxy, causing errors
when it was accessed. Thus to allow subscripting,
addition, and other operators on Python object,
the Proxy class need to implement all dunder
methods checked by the bytecode (with a lookup
on the delegate).