### PR TITLE
Unproxy arguments to dunder methods

### DIFF
--- a/optapy-core/tests/test_domain.py
+++ b/optapy-core/tests/test_domain.py
@@ -2,6 +2,7 @@ import optapy
 import optapy.score
 import optapy.config
 import optapy.constraint
+import dataclasses
 
 
 def test_single_property():
@@ -73,6 +74,93 @@ def test_single_property():
     solution = solver.solve(problem)
     assert solution.get_score().getScore() == 1
     assert solution.entity.value == '1'
+
+
+def test_tuple_group_by_key():
+    @optapy.planning_entity
+    class Entity:
+        def __init__(self, code, value=None):
+            self.code = code
+            self.value = value
+
+        @optapy.planning_variable(str, value_range_provider_refs=['value_range'])
+        def get_value(self):
+            return self.value
+
+        def set_value(self, value):
+            self.value = value
+
+    @optapy.problem_fact
+    @dataclasses.dataclass(eq=False)
+    class Value:
+        code: str
+
+    @optapy.constraint_provider
+    def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
+        return [
+            constraint_factory.forEach(optapy.get_class(Entity))
+                .join(optapy.get_class(Value),
+                      [optapy.constraint.Joiners.equal(lambda entity: entity.value,
+                                                       lambda value: value.code)])
+                .groupBy(lambda entity, value: (0, value), optapy.constraint.ConstraintCollectors.countBi())
+                .reward('Same as value', optapy.score.SimpleScore.ONE, lambda _, count: count),
+        ]
+
+    @optapy.planning_solution
+    class Solution:
+        def __init__(self, entity_list, value_list, value_range, score=None):
+            self.entity_list = entity_list
+            self.value_list = value_list
+            self.value_range = value_range
+            self.score = score
+
+        @optapy.planning_entity_collection_property(Entity)
+        def get_entity_list(self):
+            return self.entity_list
+
+        @optapy.problem_fact_collection_property(Value)
+        def get_value_list(self):
+            return self.value_list
+
+        @optapy.problem_fact_collection_property(str)
+        @optapy.value_range_provider(range_id='value_range')
+        def get_value_range(self):
+            return self.value_range
+
+        @optapy.planning_score(optapy.score.SimpleScore)
+        def get_score(self) -> optapy.score.SimpleScore:
+            return self.score
+
+        def set_score(self, score):
+            self.score = score
+
+    entity_list = [Entity('A0'), Entity('B0'), Entity('C0'),
+                   Entity('A1'), Entity('B1'), Entity('C1'),
+                   Entity('A2'), Entity('B2'), Entity('C2'),
+                   Entity('A3'), Entity('B3'), Entity('C3'),
+                   Entity('A4'), Entity('B4'), Entity('C4'),
+                   Entity('A5'), Entity('B5'), Entity('C5'),
+                   Entity('A6'), Entity('B6'), Entity('C6'),
+                   Entity('A7'), Entity('B7'), Entity('C7'),
+                   Entity('A8'), Entity('B8'), Entity('C8'),
+                   Entity('A9'), Entity('B9'), Entity('C9')]
+
+    solver_config = optapy.config.solver.SolverConfig()
+    termination_config = optapy.config.solver.termination.TerminationConfig()
+    termination_config.setBestScoreLimit(str(len(entity_list)))
+    solver_config.withSolutionClass(optapy.get_class(Solution)) \
+        .withEntityClasses(optapy.get_class(Entity)) \
+        .withConstraintProviderClass(optapy.get_class(my_constraints)) \
+        .withTerminationConfig(termination_config)
+
+    problem: Solution = Solution(entity_list,
+                                 [Value('1')],
+                                 ['1', '2', '3'])
+    solver = optapy.solver_factory_create(solver_config).buildSolver()
+    solution = solver.solve(problem)
+    assert solution.get_score().getScore() == len(entity_list)
+    for entity in solution.entity_list:
+        assert entity.value == '1'
 
 
 def test_python_object():


### PR DESCRIPTION
For certain generated methods, such as those
generated by dataclasses, may use is comparisions
which do not invoke any dunder method and thus fail
for proxies. Thus, before passing the arguments to
the dunder method, they must be unproxied so the
dunder method return the correct result.

This was a particular issue for dataclasses with eq=False,
since they use "is" comparsions, causing a uncomparable
exception if they were used as a tuple in a groupby key
(and just overall being incorrect).