### PR TITLE
Upgrade to OptaPlanner 8.21.0.Final and JPype 1.4.0

### DIFF
--- a/optapy-core/pom.xml
+++ b/optapy-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0.Final</version>
+    <version>8.21.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>optapy</artifactId>

--- a/optapy-core/pyproject.toml
+++ b/optapy-core/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     # https://github.com/pypa/setuptools/issues/2849
     "setuptools==58.4.0",
     "stubgenj>=0.2.5",
-    "JPype1>=1.3.0",
+    "JPype1>=1.4.0",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/optapy-core/setup.py
+++ b/optapy-core/setup.py
@@ -98,7 +98,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='optapy',
-    version='8.19.0a1',
+    version='8.21.0a0',
     license='Apache License Version 2.0',
     license_file='LICENSE',
     description='An AI constraint solver that optimizes planning and scheduling problems',
@@ -132,7 +132,7 @@ setup(
     test_suite='tests',
     python_requires='>=3.9',
     install_requires=[
-        'JPype1',
+        'JPype1>=1.4.0',
     ],
     cmdclass={'build_py': FetchDependencies},
     package_data={

--- a/optapy-core/src/main/python/annotations.py
+++ b/optapy-core/src/main/python/annotations.py
@@ -597,7 +597,12 @@ def constraint_provider(constraint_provider_function: Callable[['_ConstraintFact
     :rtype: Callable[[ConstraintFactory], List[Constraint]]
     """
     ensure_init()
-    constraint_provider_function.__optapy_java_class = _generate_constraint_provider_class(constraint_provider_function)
+    def wrapped_constraint_provider_function(constraint_factory: '_ConstraintFactory'):
+        from .constraint_stream import PythonConstraintFactory
+        return constraint_provider_function(PythonConstraintFactory(constraint_factory))
+
+    constraint_provider_function.__optapy_java_class = _generate_constraint_provider_class(constraint_provider_function,
+                                                                                           wrapped_constraint_provider_function)
     return constraint_provider_function
 
 

--- a/optapy-core/src/main/python/constraint/__init__.py
+++ b/optapy-core/src/main/python/constraint/__init__.py
@@ -114,9 +114,7 @@ class DefaultConstraintMatchTotal:
             raise ValueError(f'The ConstraintMatchTotal ({self}) could not remove the ConstraintMatch'
                              f'({constraint_match}) from its constraint_match_set ({self.constraint_match_set}).')
 
-# Workaround for https://github.com/jpype-project/jpype/issues/1016
-# TODO: Remove EVERYTHING below when https://github.com/jpype-project/jpype/issues/1016 is resolved
-#       and a new version of JPype is released
+# Below is needed so unknown Python objects can properly be proxied
 from jpype import JImplements, JOverride # noqa
 from ..jpype_type_conversions import PythonFunction as _PythonFunction, PythonBiFunction as _PythonBiFunction, \
     PythonTriFunction as _PythonTriFunction, PythonQuadFunction as _PythonQuadFunction,\

--- a/optapy-core/src/main/python/constraint_stream.py
+++ b/optapy-core/src/main/python/constraint_stream.py
@@ -1,0 +1,914 @@
+
+import dataclasses
+
+from .optaplanner_java_interop import get_class
+from .jpype_type_conversions import _convert_to_java_compatible_object
+from .jpype_type_conversions import PythonFunction, PythonBiFunction, PythonTriFunction, PythonQuadFunction, \
+    PythonPentaFunction, PythonToIntFunction, PythonToIntBiFunction, PythonToIntTriFunction, PythonToIntQuadFunction, \
+    PythonPredicate, PythonBiPredicate, PythonTriPredicate, PythonQuadPredicate, PythonPentaPredicate
+import jpype.imports  # noqa
+from jpype import JImplements, JOverride, JObject, JClass, JInt
+import inspect
+from typing import TYPE_CHECKING, Type, List, Optional, Callable
+if TYPE_CHECKING:
+    from org.optaplanner.core.api.score.stream import ConstraintFactory
+    from org.optaplanner.core.api.score.stream.uni import UniConstraintStream
+    from org.optaplanner.core.api.score.stream.bi import BiConstraintStream, BiJoiner
+    from org.optaplanner.core.api.score.stream.tri import TriConstraintStream, TriJoiner
+    from org.optaplanner.core.api.score.stream.quad import QuadConstraintStream, QuadJoiner
+    from org.optaplanner.core.api.score.stream.penta import PentaJoiner
+    from org.optaplanner.core.api.score import Score
+
+
+def function_cast(function):
+    arg_count = len(inspect.signature(function).parameters)
+    return default_function_cast(function, arg_count)
+
+
+def default_function_cast(function, arg_count):
+    if arg_count == 1:
+        return PythonFunction(lambda a: _convert_to_java_compatible_object(function(a)))
+    elif arg_count == 2:
+        return PythonBiFunction(lambda a, b: _convert_to_java_compatible_object(function(a, b)))
+    elif arg_count == 3:
+        return PythonTriFunction(lambda a, b, c: _convert_to_java_compatible_object(function(a, b, c)))
+    elif arg_count == 4:
+        return PythonQuadFunction(lambda a, b, c, d: _convert_to_java_compatible_object(function(a, b, c, d)))
+    elif arg_count == 5:
+        return PythonPentaFunction(lambda a, b, c, d, e: _convert_to_java_compatible_object(function(a, b, c, d, e)))
+    else:
+        raise ValueError
+
+
+def predicate_cast(predicate):
+    arg_count = len(inspect.signature(predicate).parameters)
+    return default_predicate_cast(predicate, arg_count)
+
+
+def default_predicate_cast(predicate, arg_count):
+    if arg_count == 1:
+        return PythonPredicate(predicate)
+    elif arg_count == 2:
+        return PythonBiPredicate(predicate)
+    elif arg_count == 3:
+        return PythonTriPredicate(predicate)
+    elif arg_count == 4:
+        return PythonQuadPredicate(predicate)
+    elif arg_count == 5:
+        return PythonPentaPredicate(predicate)
+    else:
+        raise ValueError
+
+
+def to_int_function_cast(function):
+    arg_count = len(inspect.signature(function).parameters)
+    return default_to_int_function_cast(function, arg_count)
+
+
+def default_to_int_function_cast(function, arg_count):
+    if arg_count == 1:
+        return PythonToIntFunction(function)
+    elif arg_count == 2:
+        return PythonToIntBiFunction(function)
+    elif arg_count == 3:
+        return PythonToIntTriFunction(function)
+    elif arg_count == 4:
+        return PythonToIntQuadFunction(function)
+    else:
+        raise ValueError
+
+
+def extract_joiners(joiner_tuple, *stream_types):
+    from org.optaplanner.core.api.score.stream.bi import BiJoiner
+    from org.optaplanner.core.api.score.stream.tri import TriJoiner
+    from org.optaplanner.core.api.score.stream.quad import QuadJoiner
+    from org.optaplanner.core.api.score.stream.penta import PentaJoiner
+
+    if len(joiner_tuple) == 1 and (isinstance(joiner_tuple[0], list) or isinstance(joiner_tuple[0], tuple)):
+        joiner_tuple = joiner_tuple[0]  # Joiners was passed as a list of Joiners instead of varargs
+    array_size = len(joiner_tuple)
+    output_array = None
+    array_type = None
+    if len(stream_types) == 2:
+        array_type = BiJoiner
+        output_array = BiJoiner[array_size]
+    elif len(stream_types) == 3:
+        array_type = TriJoiner
+        output_array = TriJoiner[array_size]
+    elif len(stream_types) == 4:
+        array_type = QuadJoiner
+        output_array = QuadJoiner[array_size]
+    elif len(stream_types) == 5:
+        array_type = PentaJoiner
+        output_array = PentaJoiner[array_size]
+    else:
+        raise ValueError
+
+    for i in range(array_size):
+        output_array[i] = (array_type) @ (joiner_tuple[i])
+
+    return output_array
+
+
+@dataclasses.dataclass
+class ConstraintInfo:
+    constraint_package: str
+    constraint_name: str
+    score: Optional['Score']
+    impact_function: Optional[Callable]
+
+
+def extract_constraint_info(default_package: str, args: tuple) -> ConstraintInfo:
+    from org.optaplanner.core.api.score import Score
+    constraint_package = default_package
+    constraint_name = None
+    if isinstance(args[1], str):
+        constraint_package = args[0]
+        constraint_name = args[1]
+        args = args[2:]
+    else:
+        constraint_name = args[0]
+        args = args[1:]
+
+    if len(args) == 0:
+        return ConstraintInfo(constraint_package, constraint_name, None, None)
+
+    if isinstance(args[0], Score):
+        score = args[0]
+        args = args[1:]
+    else:
+        score = None
+
+    if len(args) == 0:
+        return ConstraintInfo(constraint_package, constraint_name, score, None)
+    else:
+        return ConstraintInfo(constraint_package, constraint_name, score, args[0])
+
+
+def perform_group_by(delegate, package, group_by_args, *type_arguments):
+    actual_group_by_args = []
+    for i in range(len(group_by_args)):
+        if callable(group_by_args[i]):
+            actual_group_by_args.append(function_cast(group_by_args[i]))
+        else:
+            actual_group_by_args.append(group_by_args[i])
+
+    if len(group_by_args) == 1:
+        return PythonUniConstraintStream(delegate.groupBy(*actual_group_by_args), package, JClass('java.lang.Object'))
+    elif len(group_by_args) == 2:
+        return PythonBiConstraintStream(delegate.groupBy(*actual_group_by_args), package, JClass('java.lang.Object'),
+                                        JClass('java.lang.Object'))
+    elif len(group_by_args) == 3:
+        return PythonTriConstraintStream(delegate.groupBy(*actual_group_by_args), package, JClass('java.lang.Object'),
+                                         JClass('java.lang.Object'), JClass('java.lang.Object'))
+    elif len(group_by_args) == 4:
+        return PythonQuadConstraintStream(delegate.groupBy(*actual_group_by_args), package, JClass('java.lang.Object'),
+                                          JClass('java.lang.Object'), JClass('java.lang.Object'),
+                                          JClass('java.lang.Object'))
+    else:
+        raise ValueError
+
+
+class PythonConstraintFactory:
+    delegate: 'ConstraintFactory'
+
+    def __init__(self, delegate: 'ConstraintFactory'):
+        self.delegate = delegate
+
+    def getDefaultConstraintPackage(self) -> str:
+        return self.delegate.getDefaultConstraintPackage()
+
+    def forEach(self, item_type: Type) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.forEach(item_type), self.getDefaultConstraintPackage(),
+                                         item_type)
+
+    def forEachIncludingNullVars(self, item_type: Type) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.forEachIncludingNullVars(item_type),
+                                         self.getDefaultConstraintPackage(), item_type)
+
+    def forEachUniquePair(self, item_type: Type, *joiners: List['BiJoiner']):
+        item_type = get_class(item_type)
+        return PythonBiConstraintStream(self.delegate.forEachUniquePair(item_type,
+                                                                        extract_joiners(joiners, item_type, item_type)),
+                                        self.getDefaultConstraintPackage(), item_type, item_type)
+
+    def from_(self, item_type: Type) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.from_(item_type), self.getDefaultConstraintPackage(),
+                                         item_type)
+
+    def fromUnfiltered(self, item_type: Type) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.fromUnfiltered(item_type), self.getDefaultConstraintPackage(),
+                                         item_type)
+
+    def fromUniquePair(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonBiConstraintStream':
+        item_type = get_class(item_type)
+        return PythonBiConstraintStream(self.delegate.fromUniquePair(item_type,
+                                                                     extract_joiners(joiners, item_type, item_type)),
+                                        self.getDefaultConstraintPackage(), item_type, item_type)
+
+
+
+class PythonUniConstraintStream:
+    delegate: 'UniConstraintStream'
+    package: str
+    a_type: Type
+
+    def __init__(self, delegate: 'UniConstraintStream', package: str, a_type: Type):
+        self.delegate = delegate
+        self.package = package
+        self.a_type = a_type
+
+    def filter(self, predicate) -> 'PythonUniConstraintStream':
+        translated_predicate = predicate_cast(predicate)
+        return PythonUniConstraintStream(self.delegate.filter(translated_predicate), self.package, self.a_type)
+
+    def join(self, unistream_or_type, *joiners: List['BiJoiner']) -> 'PythonBiConstraintStream':
+        b_type = None
+        if isinstance(unistream_or_type, PythonUniConstraintStream):
+            b_type = unistream_or_type.a_type
+        else:
+            b_type = get_class(unistream_or_type)
+            unistream_or_type = b_type
+
+        join_result = self.delegate.join(unistream_or_type, extract_joiners(joiners, self.a_type, b_type))
+        return PythonBiConstraintStream(join_result, self.package, self.a_type, b_type)
+
+    def ifExists(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.ifExists(item_type,
+                                                                extract_joiners(joiners, self.a_type, item_type)),
+                                         self.package, self.a_type)
+
+    def ifExistsIncludingNullVars(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.ifExistsIncludingNullVars(item_type,
+                                                                                 extract_joiners(joiners, self.a_type,
+                                                                                                 item_type)),
+                                         self.package,
+                                         self.a_type)
+
+    def ifExistsOther(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.ifExistsOther(item_type, extract_joiners(joiners, self.a_type,
+                                                                                                item_type)),
+                                         self.package, self.a_type)
+
+    def ifExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.ifExistsOtherIncludingNullVars(item_type,
+                                                                                      extract_joiners(joiners,
+                                                                                                      self.a_type,
+                                                                                                      item_type)),
+                                         self.package,
+                                         self.a_type)
+
+    def ifNotExists(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.ifNotExists(item_type, extract_joiners(joiners, self.a_type,
+                                                                                              item_type)),
+                                         self.package, self.a_type)
+
+    def ifNotExistsIncludingNullVars(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.ifNotExistsIncludingNullVars(item_type,
+                                                                                    extract_joiners(joiners,
+                                                                                                    self.a_type,
+                                                                                                    item_type)),
+                                         self.package,
+                                         self.a_type)
+
+    def ifNotExistsOther(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.ifNotExistsOther(item_type, extract_joiners(joiners, self.a_type,
+                                                                                                   item_type)),
+                                         self.package,
+                                         self.a_type)
+
+    def ifNotExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+        item_type = get_class(item_type)
+        return PythonUniConstraintStream(self.delegate.ifNotExistsOtherIncludingNullVars(item_type,
+                                                                                         extract_joiners(joiners,
+                                                                                                         self.a_type,
+                                                                                                         item_type)),
+                                         self.package, self.a_type)
+
+    def groupBy(self, *args):
+        return perform_group_by(self.delegate, self.package, args, self.a_type)
+
+    def map(self, mapping_function) -> 'PythonUniConstraintStream':
+        translated_function = function_cast(mapping_function)
+        return PythonUniConstraintStream(self.delegate.map(translated_function), self.package,
+                                         JClass('java.lang.Object'))
+
+    def flattenLast(self, flattening_function) -> 'PythonUniConstraintStream':
+        translated_function = function_cast(flattening_function)
+        return PythonUniConstraintStream(self.delegate.flattenLast(translated_function), self.package,
+                                         JClass('java.lang.Object'))
+
+    def distinct(self) -> 'PythonUniConstraintStream':
+        return PythonUniConstraintStream(self.delegate.distinct(), self.package, self.a_type)
+
+    def penalize(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
+                                          constraint_info.score)
+        else:
+            return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
+                                          constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def penalizeLong(self, *args):
+        raise NotImplementedError
+
+    def penalizeBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurable(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurableLong(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurableBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def reward(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score)
+        else:
+            return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def rewardLong(self, *args):
+        raise NotImplementedError
+
+    def rewardBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def rewardConfigurable(self, *args):
+        raise NotImplementedError
+
+    def impact(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score)
+        else:
+            return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def impactLong(self, *args):
+        raise NotImplementedError
+
+    def impactBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def impactConfigurable(self, *args):
+        raise NotImplementedError
+
+
+class PythonBiConstraintStream:
+    delegate: 'BiConstraintStream'
+    package: str
+    a_type: Type
+    b_type: Type
+
+    def __init__(self, delegate: 'BiConstraintStream', package: str, a_type: Type, b_type: Type):
+        self.delegate = delegate
+        self.package = package
+        self.a_type = a_type
+        self.b_type = b_type
+
+    def filter(self, predicate) -> 'PythonBiConstraintStream':
+        translated_predicate = predicate_cast(predicate)
+        return PythonBiConstraintStream(self.delegate.filter(translated_predicate), self.package, self.a_type,
+                                        self.b_type)
+
+    def join(self, unistream_or_type, *joiners: List['TriJoiner']) -> 'PythonTriConstraintStream':
+        c_type = None
+        if isinstance(unistream_or_type, PythonUniConstraintStream):
+            c_type = unistream_or_type.a_type
+        else:
+            c_type = get_class(unistream_or_type)
+            unistream_or_type = c_type
+
+        join_result = self.delegate.join(unistream_or_type, extract_joiners(joiners, self.a_type, self.b_type, c_type))
+        return PythonTriConstraintStream(join_result, self.package, self.a_type, self.b_type, c_type)
+
+    def ifExists(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
+        item_type = get_class(item_type)
+        return PythonBiConstraintStream(self.delegate.ifExists(item_type,
+                                                               extract_joiners(joiners, self.a_type,
+                                                                               self.b_type, item_type)),
+                                        self.package, self.a_type, self.b_type)
+
+    def ifExistsIncludingNullVars(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
+        item_type = get_class(item_type)
+        return PythonBiConstraintStream(self.delegate.ifExistsIncludingNullVars(item_type, extract_joiners(joiners,
+                                                                                                           self.a_type,
+                                                                                                           self.b_type,
+                                                                                                           item_type)),
+                                        self.package,
+                                        self.a_type, self.b_type)
+
+    def ifExistsOther(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
+        item_type = get_class(item_type)
+        return PythonBiConstraintStream(self.delegate.ifExistsOther(item_type, extract_joiners(joiners, self.a_type,
+                                                                                               self.b_type, item_type)),
+                                        self.package, self.a_type,
+                                        self.b_type)
+
+    def ifExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
+        item_type = get_class(item_type)
+        return PythonBiConstraintStream(self.delegate.ifExistsOtherIncludingNullVars(item_type,
+                                                                                     extract_joiners(joiners,
+                                                                                                     self.a_type,
+                                                                                                     self.b_type,
+                                                                                                     item_type)),
+                                        self.package, self.a_type, self.b_type)
+
+    def ifNotExists(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
+        item_type = get_class(item_type)
+        return PythonBiConstraintStream(self.delegate.ifNotExists(item_type, extract_joiners(joiners, self.a_type,
+                                                                                             self.b_type, item_type)),
+                                        self.package, self.a_type, self.b_type)
+
+    def ifNotExistsIncludingNullVars(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
+        item_type = get_class(item_type)
+        return PythonBiConstraintStream(self.delegate.ifNotExistsIncludingNullVars(item_type,
+                                                                                   extract_joiners(joiners,
+                                                                                                   self.a_type,
+                                                                                                   self.b_type,
+                                                                                                   item_type)),
+                                        self.package, self.a_type, self.b_type)
+
+    def ifNotExistsOther(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
+        item_type = get_class(item_type)
+        return PythonBiConstraintStream(self.delegate.ifNotExistsOther(item_type,
+                                                                       extract_joiners(joiners,
+                                                                                       self.a_type,
+                                                                                       self.b_type,
+                                                                                       item_type)),
+                                        self.package, self.a_type, self.b_type)
+
+    def ifNotExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
+        item_type = get_class(item_type)
+        return PythonBiConstraintStream(self.delegate.ifNotExistsOtherIncludingNullVars(item_type,
+                                                                                        extract_joiners(joiners,
+                                                                                                        self.a_type,
+                                                                                                        self.b_type,
+                                                                                                        item_type)),
+                                        self.package, self.a_type, self.b_type)
+
+    def groupBy(self, *args):
+        return perform_group_by(self.delegate, self.package, args, self.a_type, self.b_type)
+
+    def map(self, mapping_function) -> 'PythonUniConstraintStream':
+        translated_function = function_cast(mapping_function)
+        return PythonUniConstraintStream(self.delegate.map(translated_function), self.package, JClass('java.lang.Object'))
+
+    def flattenLast(self, flattening_function) -> 'PythonBiConstraintStream':
+        translated_function = function_cast(flattening_function)
+        return PythonBiConstraintStream(self.delegate.flattenLast(translated_function), self.package,
+                                        self.a_type, JClass('java.lang.Object'))
+
+    def distinct(self) -> 'PythonBiConstraintStream':
+        return PythonBiConstraintStream(self.delegate.distinct(), self.package, self.a_type, self.b_type)
+
+    def penalize(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
+                                          constraint_info.score)
+        else:
+            return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
+                                          constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def penalizeLong(self, *args):
+        raise NotImplementedError
+
+    def penalizeBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurable(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurableLong(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurableBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def reward(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score)
+        else:
+            return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def rewardLong(self, *args):
+        raise NotImplementedError
+
+    def rewardBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def rewardConfigurable(self, *args):
+        raise NotImplementedError
+
+    def impact(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score)
+        else:
+            return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def impactLong(self, *args):
+        raise NotImplementedError
+
+    def impactBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def impactConfigurable(self, *args):
+        raise NotImplementedError
+
+
+class PythonTriConstraintStream:
+    delegate: 'TriConstraintStream'
+    package: str
+    a_type: Type
+    b_type: Type
+    c_type: Type
+
+    def __init__(self, delegate: 'TriConstraintStream', package: str, a_type: Type, b_type: Type, c_type: Type):
+        self.delegate = delegate
+        self.package = package
+        self.a_type = a_type
+        self.b_type = b_type
+        self.c_type = c_type
+
+    def filter(self, predicate) -> 'PythonTriConstraintStream':
+        translated_predicate = predicate_cast(predicate)
+        return PythonTriConstraintStream(self.delegate.filter(translated_predicate), self.package, self.a_type,
+                                         self.b_type, self.c_type)
+
+    def join(self, unistream_or_type, *joiners: List['QuadJoiner']) -> 'PythonQuadConstraintStream':
+        d_type = None
+        if isinstance(unistream_or_type, PythonUniConstraintStream):
+            d_type = unistream_or_type.a_type
+        else:
+            d_type = get_class(unistream_or_type)
+            unistream_or_type = d_type
+
+        join_result = self.delegate.join(unistream_or_type, extract_joiners(joiners, self.a_type, self.b_type,
+                                                                            self.c_type, d_type))
+        return PythonQuadConstraintStream(join_result, self.package, self.a_type, self.b_type, self.c_type, d_type)
+
+    def ifExists(self, item_type: Type, *joiners: List['QuadJoiner']) -> 'PythonTriConstraintStream':
+        item_type = get_class(item_type)
+        return PythonTriConstraintStream(self.delegate.ifExists(item_type, extract_joiners(joiners, self.a_type,
+                                                                                           self.b_type, self.c_type,
+                                                                                           item_type)), self.package,
+                                         self.a_type, self.b_type, self.c_type)
+
+    def ifExistsIncludingNullVars(self, item_type: Type, *joiners: List['QuadJoiner']) -> 'PythonTriConstraintStream':
+        item_type = get_class(item_type)
+        return PythonTriConstraintStream(self.delegate.ifExistsIncludingNullVars(item_type, extract_joiners(joiners,
+                                                                                                            self.a_type,
+                                                                                                            self.b_type,
+                                                                                                            self.c_type,
+                                                                                                            item_type)),
+                                         self.package, self.a_type, self.b_type, self.c_type)
+
+    def ifExistsOther(self, item_type: Type, *joiners: List['QuadJoiner']) -> 'PythonTriConstraintStream':
+        item_type = get_class(item_type)
+        return PythonTriConstraintStream(self.delegate.ifExistsOther(item_type, extract_joiners(joiners,
+                                                                                                self.a_type,
+                                                                                                self.b_type,
+                                                                                                self.c_type,
+                                                                                                item_type)),
+                                         self.package, self.a_type, self.b_type, self.c_type)
+
+    def ifExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['QuadJoiner']) \
+            -> 'PythonTriConstraintStream':
+        item_type = get_class(item_type)
+        return PythonTriConstraintStream(self.delegate.ifExistsOtherIncludingNullVars(item_type,
+                                                                                      extract_joiners(joiners,
+                                                                                                      self.a_type,
+                                                                                                      self.b_type,
+                                                                                                      self.c_type,
+                                                                                                      item_type)),
+                                         self.package, self.a_type, self.b_type, self.c_type)
+
+    def ifNotExists(self, item_type: Type, *joiners: List['QuadJoiner']) -> 'PythonTriConstraintStream':
+        item_type = get_class(item_type)
+        return PythonTriConstraintStream(self.delegate.ifNotExists(item_type, extract_joiners(joiners,
+                                                                                              self.a_type,
+                                                                                              self.b_type,
+                                                                                              self.c_type,
+                                                                                              item_type)),
+                                         self.package, self.a_type, self.b_type, self.c_type)
+
+    def ifNotExistsIncludingNullVars(self, item_type: Type, *joiners: List['QuadJoiner']) \
+            -> 'PythonTriConstraintStream':
+        item_type = get_class(item_type)
+        return PythonTriConstraintStream(self.delegate.ifNotExistsIncludingNullVars(item_type,
+                                                                                    extract_joiners(joiners,
+                                                                                                    self.a_type,
+                                                                                                    self.b_type,
+                                                                                                    self.c_type,
+                                                                                                    item_type)),
+                                         self.package, self.a_type, self.b_type, self.c_type)
+
+    def ifNotExistsOther(self, item_type: Type, *joiners: List['QuadJoiner']) -> 'PythonTriConstraintStream':
+        item_type = get_class(item_type)
+        return PythonTriConstraintStream(self.delegate.ifNotExistsOther(item_type, extract_joiners(joiners,
+                                                                                                   self.a_type,
+                                                                                                   self.b_type,
+                                                                                                   self.c_type,
+                                                                                                   item_type)),
+                                         self.package, self.a_type, self.b_type, self.c_type)
+
+    def ifNotExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['QuadJoiner']) \
+            -> 'PythonTriConstraintStream':
+        item_type = get_class(item_type)
+        return PythonTriConstraintStream(self.delegate.ifNotExistsOtherIncludingNullVars(item_type,
+                                                                                         extract_joiners(joiners,
+                                                                                                         self.a_type,
+                                                                                                         self.b_type,
+                                                                                                         self.c_type,
+                                                                                                         item_type)),
+                                         self.package, self.a_type, self.b_type, self.c_type)
+
+    def groupBy(self, *args):
+        return perform_group_by(self.delegate, self.package, args, self.a_type, self.b_type, self.c_type)
+
+    def map(self, mapping_function) -> 'PythonUniConstraintStream':
+        translated_function = function_cast(mapping_function)
+        return PythonUniConstraintStream(self.delegate.map(translated_function), self.package,
+                                         JClass('java.lang.Object'))
+
+    def flattenLast(self, flattening_function) -> 'PythonTriConstraintStream':
+        translated_function = function_cast(flattening_function)
+        return PythonTriConstraintStream(self.delegate.flattenLast(translated_function), self.package,
+                                         self.a_type, self.b_type, JClass('java.lang.Object'))
+
+    def distinct(self) -> 'PythonTriConstraintStream':
+        return PythonTriConstraintStream(self.delegate.distinct(), self.package, self.a_type,
+                                         self.b_type, self.c_type)
+
+    def penalize(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
+                                          constraint_info.score)
+        else:
+            return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
+                                          constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def penalizeLong(self, *args):
+        raise NotImplementedError
+
+    def penalizeBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurable(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurableLong(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurableBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def reward(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score)
+        else:
+            return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def rewardLong(self, *args):
+        raise NotImplementedError
+
+    def rewardBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def rewardConfigurable(self, *args):
+        raise NotImplementedError
+
+    def impact(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score)
+        else:
+            return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def impactLong(self, *args):
+        raise NotImplementedError
+
+    def impactBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def impactConfigurable(self, *args):
+        raise NotImplementedError
+
+
+class PythonQuadConstraintStream:
+    delegate: 'QuadConstraintStream'
+    package: str
+    a_type: Type
+    b_type: Type
+    c_type: Type
+    d_type: Type
+
+    def __init__(self, delegate: 'QuadConstraintStream', package: str, a_type: Type, b_type: Type, c_type: Type,
+                 d_type: type):
+        self.delegate = delegate
+        self.package = package
+        self.a_type = a_type
+        self.b_type = b_type
+        self.c_type = c_type
+        self.d_type = d_type
+
+    def filter(self, predicate) -> 'PythonQuadConstraintStream':
+        translated_predicate = predicate_cast(predicate)
+        return PythonQuadConstraintStream(self.delegate.filter(translated_predicate), self.package, self.a_type,
+                                          self.b_type, self.c_type, self.d_type)
+
+    def ifExists(self, item_type: Type, *joiners: List['PentaJoiner']) -> 'PythonQuadConstraintStream':
+        item_type = get_class(item_type)
+        return PythonQuadConstraintStream(self.delegate.ifExists(item_type, extract_joiners(joiners,
+                                                                                            self.a_type,
+                                                                                            self.b_type,
+                                                                                            self.c_type,
+                                                                                            self.d_type,
+                                                                                            item_type)),
+                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+
+    def ifExistsIncludingNullVars(self, item_type: Type, *joiners: List['PentaJoiner']) -> 'PythonQuadConstraintStream':
+        item_type = get_class(item_type)
+        return PythonQuadConstraintStream(self.delegate.ifExistsIncludingNullVars(item_type,
+                                                                                  extract_joiners(joiners,
+                                                                                                  self.a_type,
+                                                                                                  self.b_type,
+                                                                                                  self.c_type,
+                                                                                                  self.d_type,
+                                                                                                  item_type)),
+                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+
+    def ifExistsOther(self, item_type: Type, *joiners: List['PentaJoiner']) -> 'PythonQuadConstraintStream':
+        item_type = get_class(item_type)
+        return PythonQuadConstraintStream(self.delegate.ifExistsOther(item_type, extract_joiners(joiners,
+                                                                                                 self.a_type,
+                                                                                                 self.b_type,
+                                                                                                 self.c_type,
+                                                                                                 self.d_type,
+                                                                                                 item_type)),
+                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+
+    def ifExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['PentaJoiner']) \
+            -> 'PythonQuadConstraintStream':
+        item_type = get_class(item_type)
+        return PythonQuadConstraintStream(self.delegate.ifExistsOtherIncludingNullVars(item_type,
+                                                                                       extract_joiners(joiners,
+                                                                                                       self.a_type,
+                                                                                                       self.b_type,
+                                                                                                       self.c_type,
+                                                                                                       self.d_type,
+                                                                                                       item_type)),
+                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+
+    def ifNotExists(self, item_type: Type, *joiners: List['PentaJoiner']) -> 'PythonQuadConstraintStream':
+        item_type = get_class(item_type)
+        return PythonQuadConstraintStream(self.delegate.ifNotExists(item_type, extract_joiners(joiners,
+                                                                                               self.a_type,
+                                                                                               self.b_type,
+                                                                                               self.c_type,
+                                                                                               self.d_type,
+                                                                                               item_type)),
+                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+
+    def ifNotExistsIncludingNullVars(self, item_type: Type, *joiners: List['PentaJoiner']) \
+            -> 'PythonQuadConstraintStream':
+        item_type = get_class(item_type)
+        return PythonQuadConstraintStream(self.delegate.ifNotExistsIncludingNullVars(item_type,
+                                                                                     extract_joiners(joiners,
+                                                                                                     self.a_type,
+                                                                                                     self.b_type,
+                                                                                                     self.c_type,
+                                                                                                     self.d_type,
+                                                                                                     item_type)),
+                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+
+    def ifNotExistsOther(self, item_type: Type, *joiners: List['PentaJoiner']) -> 'PythonQuadConstraintStream':
+        item_type = get_class(item_type)
+        return PythonQuadConstraintStream(self.delegate.ifNotExistsOther(item_type, extract_joiners(joiners,
+                                                                                                    self.a_type,
+                                                                                                    self.b_type,
+                                                                                                    self.c_type,
+                                                                                                    self.d_type,
+                                                                                                    item_type)),
+                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+
+    def ifNotExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['PentaJoiner']) \
+            -> 'PythonQuadConstraintStream':
+        item_type = get_class(item_type)
+        return PythonQuadConstraintStream(self.delegate.ifNotExistsOtherIncludingNullVars(item_type,
+                                                                                          extract_joiners(joiners,
+                                                                                                          self.a_type,
+                                                                                                          self.b_type,
+                                                                                                          self.c_type,
+                                                                                                          self.d_type,
+                                                                                                          item_type)),
+                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+
+    def groupBy(self, *args):
+        return perform_group_by(self.delegate, self.package, args, self.a_type, self.b_type, self.c_type, self.d_type)
+
+    def map(self, mapping_function) -> 'PythonUniConstraintStream':
+        translated_function = function_cast(mapping_function)
+        return PythonUniConstraintStream(self.delegate.map(translated_function), self.package,
+                                         JClass('java.lang.Object'))
+
+    def flattenLast(self, flattening_function) -> 'PythonQuadConstraintStream':
+        translated_function = function_cast(flattening_function)
+        return PythonQuadConstraintStream(self.delegate.flattenLast(translated_function), self.package,
+                                          self.a_type, self.b_type, self.c_type, JClass('java.lang.Object'))
+
+    def distinct(self) -> 'PythonQuadConstraintStream':
+        return PythonQuadConstraintStream(self.delegate.distinct(), self.package, self.a_type,
+                                          self.b_type, self.c_type, self.d_type)
+
+    def penalize(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
+                                          constraint_info.score)
+        else:
+            return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
+                                          constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def penalizeLong(self, *args):
+        raise NotImplementedError
+
+    def penalizeBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurable(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurableLong(self, *args):
+        raise NotImplementedError
+
+    def penalizeConfigurableBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def reward(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score)
+        else:
+            return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def rewardLong(self, *args):
+        raise NotImplementedError
+
+    def rewardBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def rewardConfigurable(self, *args):
+        raise NotImplementedError
+
+    def impact(self, *args):
+        constraint_info = extract_constraint_info(self.package, args)
+        if constraint_info.impact_function is None:
+            return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score)
+        else:
+            return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
+                                        constraint_info.score, to_int_function_cast(constraint_info.impact_function))
+
+    def impactLong(self, *args):
+        raise NotImplementedError
+
+    def impactBigDecimal(self, *args):
+        raise NotImplementedError
+
+    def impactConfigurable(self, *args):
+        raise NotImplementedError

--- a/optapy-core/src/main/python/jpype_type_conversions.py
+++ b/optapy-core/src/main/python/jpype_type_conversions.py
@@ -143,29 +143,28 @@ def _convert_to_java_compatible_object(item):
     return PythonComparable(_proxy(item))
 
 
-@JConversion('java.util.function.Function', exact=FunctionType)
-def _convert_to_function(jcls, obj):
-    return PythonFunction(lambda a: _convert_to_java_compatible_object(obj(a)))
+@JConversion('java.lang.Class', exact=type)
+def _convert_type_to_class(jcls, type_obj):
+    from .optaplanner_java_interop import get_class
+    from java.lang import Object
+    out = get_class(type_obj)
+    if out == Object and type_obj != Object:
+        raise ValueError(f'Type {type_obj} does not have a Java class proxy. Maybe annotate it with '
+                         f'@problem_fact, @planning_entity, or @planning_solution?')
+
+    return out
 
 
-@JConversion('java.util.function.BiFunction', exact=FunctionType)
-def _convert_to_bi_function(jcls, obj):
-    return PythonBiFunction(lambda a, b: _convert_to_java_compatible_object(obj(a, b)))
+@JConversion('java.lang.Class', exact=FunctionType)
+def _convert_function_to_class(jcls, function_obj):
+    from .optaplanner_java_interop import get_class
+    from java.lang import Object
+    out = get_class(function_obj)
+    if out == Object and function_obj != Object:
+        raise ValueError(f'Function {function_obj} does not have a Java class proxy. Maybe annotate it with '
+                         f'@constraint_provider?')
 
-
-@JConversion('org.optaplanner.core.api.function.TriFunction', exact=FunctionType)
-def _convert_to_tri_function(jcls, obj):
-    return PythonTriFunction(lambda a, b, c: _convert_to_java_compatible_object(obj(a, b, c)))
-
-
-@JConversion('org.optaplanner.core.api.function.QuadFunction', exact=FunctionType)
-def _convert_to_quad_function(jcls, obj):
-    return PythonQuadFunction(lambda a, b, c, d: _convert_to_java_compatible_object(obj(a, b, c, d)))
-
-
-@JConversion('org.optaplanner.core.api.function.PentaFunction', exact=FunctionType)
-def _convert_to_quad_function(jcls, obj):
-    return PythonPentaFunction(lambda a, b, c, d, e: _convert_to_java_compatible_object(obj(a, b, c, d, e)))
+    return out
 
 
 @JConversion('java.util.function.ToIntFunction', exact=FunctionType)

--- a/optapy-core/src/main/python/jpype_type_conversions.py
+++ b/optapy-core/src/main/python/jpype_type_conversions.py
@@ -80,7 +80,7 @@ class PythonToIntFunction:
 
     @JOverride
     def applyAsInt(self, argument):
-        return self.delegate(argument)
+        return JInt(self.delegate(argument))
 
 
 @JImplements('java.util.function.ToIntBiFunction', deferred=True)
@@ -90,7 +90,7 @@ class PythonToIntBiFunction:
 
     @JOverride
     def applyAsInt(self, argument1, argument2):
-        return self.delegate(argument1, argument2)
+        return JInt(self.delegate(argument1, argument2))
 
 
 @JImplements('org.optaplanner.core.api.function.ToIntTriFunction', deferred=True)
@@ -100,7 +100,7 @@ class PythonToIntTriFunction:
 
     @JOverride
     def applyAsInt(self, argument1, argument2, argument3):
-        return self.delegate(argument1, argument2, argument3)
+        return JInt(self.delegate(argument1, argument2, argument3))
 
 
 @JImplements('org.optaplanner.core.api.function.ToIntQuadFunction', deferred=True)
@@ -110,7 +110,7 @@ class PythonToIntQuadFunction:
 
     @JOverride
     def applyAsInt(self, argument1, argument2, argument3, argument4):
-        return self.delegate(argument1, argument2, argument3, argument4)
+        return JInt(self.delegate(argument1, argument2, argument3, argument4))
 
 
 @JImplements('org.optaplanner.core.api.function.ToIntPentaFunction', deferred=True)
@@ -120,7 +120,59 @@ class PythonToIntPentaFunction:
 
     @JOverride
     def applyAsInt(self, argument1, argument2, argument3, argument4, argument5):
+        return JInt(self.delegate(argument1, argument2, argument3, argument4, argument5))
+
+
+
+@JImplements('java.util.function.Predicate', deferred=True)
+class PythonPredicate:
+    def __init__(self, delegate):
+        self.delegate = delegate
+
+    @JOverride
+    def test(self, argument):
+        return self.delegate(argument)
+
+
+@JImplements('java.util.function.BiPredicate', deferred=True)
+class PythonBiPredicate:
+    def __init__(self, delegate):
+        self.delegate = delegate
+
+    @JOverride
+    def test(self, argument1, argument2):
+        return self.delegate(argument1, argument2)
+
+
+@JImplements('org.optaplanner.core.api.function.TriPredicate', deferred=True)
+class PythonTriPredicate:
+    def __init__(self, delegate):
+        self.delegate = delegate
+
+    @JOverride
+    def test(self, argument1, argument2, argument3):
+        return self.delegate(argument1, argument2, argument3)
+
+
+@JImplements('org.optaplanner.core.api.function.QuadPredicate', deferred=True)
+class PythonQuadPredicate:
+    def __init__(self, delegate):
+        self.delegate = delegate
+
+    @JOverride
+    def test(self, argument1, argument2, argument3, argument4):
+        return self.delegate(argument1, argument2, argument3, argument4)
+
+
+@JImplements('org.optaplanner.core.api.function.PentaPredicate', deferred=True)
+class PythonPentaPredicate:
+    def __init__(self, delegate):
+        self.delegate = delegate
+
+    @JOverride
+    def test(self, argument1, argument2, argument3, argument4, argument5):
         return self.delegate(argument1, argument2, argument3, argument4, argument5)
+
 
 # Function convertors
 def _has_java_class(item):

--- a/optapy-core/src/main/python/optaplanner_api_wrappers.py
+++ b/optapy-core/src/main/python/optaplanner_api_wrappers.py
@@ -3,6 +3,7 @@ import pathlib
 from jpype.types import *
 from jpype import JImplements, JImplementationFor, JOverride
 from typing import TypeVar, Generic, Callable, Union, TYPE_CHECKING
+from types import FunctionType
 from uuid import uuid1 as _uuid1
 from .optaplanner_java_interop import _setup_solver_run, _cleanup_solver_run, _unwrap_java_object, \
     solver_run_id_to_refs as _solver_run_id_to_refs, get_class, \
@@ -370,4 +371,3 @@ class _PythonSolver:
             raise RuntimeError(error_message) from e
         finally:
             _cleanup_solver_run(solver_run_id)
-

--- a/optapy-core/src/main/python/optaplanner_java_interop.py
+++ b/optapy-core/src/main/python/optaplanner_java_interop.py
@@ -959,8 +959,10 @@ def _get_optaplanner_annotations(python_class: Type) -> List[Tuple[str, JClass, 
 
 def get_class(python_class: Union[Type, Callable]) -> JClass:
     """Return the Java Class for the given Python Class"""
-    from java.lang import Object
+    from java.lang import Object, Class
     if isinstance(python_class, jpype.JClass):
+        return cast(JClass, python_class)
+    if isinstance(python_class, Class):
         return cast(JClass, python_class)
     if hasattr(python_class, '__optapy_java_class'):
         return python_class.__optapy_java_class
@@ -1060,7 +1062,8 @@ def _to_constraint_java_array(python_list: List['_Constraint']) -> JArray:
     return out
 
 
-def _generate_constraint_provider_class(constraint_provider: Callable[['_ConstraintFactory'], List['_Constraint']]) -> \
+def _generate_constraint_provider_class(constraint_provider: Callable[['_ConstraintFactory'], List['_Constraint']],
+                                        wrapped_constraint_provider: Callable[['_ConstraintFactory'], List['_Constraint']]) -> \
         JClass:
     ensure_init()
     from org.optaplanner.optapy import PythonWrapperGenerator  # noqa
@@ -1068,7 +1071,7 @@ def _generate_constraint_provider_class(constraint_provider: Callable[['_Constra
     class_identifier = _get_class_identifier_for_object(constraint_provider)
     out = PythonWrapperGenerator.defineConstraintProviderClass(
         _compose_unique_class_name(class_identifier),
-        JObject(ConstraintProviderFunction(lambda cf: _to_constraint_java_array(constraint_provider(cf))),
+        JObject(ConstraintProviderFunction(lambda cf: _to_constraint_java_array(wrapped_constraint_provider(cf))),
                 ConstraintProvider))
     class_identifier_to_java_class_map[class_identifier] = out
     return out

--- a/optapy-core/tests/test_anchors.py
+++ b/optapy-core/tests/test_anchors.py
@@ -71,9 +71,10 @@ class ChainedSolution:
 @optapy.constraint_provider
 def chained_constraints(constraint_factory):
     return [
-        constraint_factory.forEach(optapy.get_class(ChainedEntity))
+        constraint_factory.forEach(ChainedEntity)
                           .groupBy(lambda entity: entity.anchor, optapy.constraint.ConstraintCollectors.count())
-                          .reward('Maximize chain length', optapy.score.SimpleScore.ONE, lambda anchor, count: count * count)
+                          .reward('Maximize chain length', optapy.score.SimpleScore.ONE,
+                                  lambda anchor, count: count * count)
     ]
 
 
@@ -81,9 +82,9 @@ def test_chained():
     termination = optapy.config.solver.termination.TerminationConfig()
     termination.setBestScoreLimit('9')
     solver_config = optapy.config.solver.SolverConfig() \
-        .withSolutionClass(optapy.get_class(ChainedSolution)) \
-        .withEntityClasses(optapy.get_class(ChainedEntity)) \
-        .withConstraintProviderClass(optapy.get_class(chained_constraints)) \
+        .withSolutionClass(ChainedSolution) \
+        .withEntityClasses(ChainedEntity) \
+        .withConstraintProviderClass(chained_constraints) \
         .withTerminationConfig(termination)
     solver = optapy.solver_factory_create(solver_config).buildSolver()
     solution = solver.solve(ChainedSolution(

--- a/optapy-core/tests/test_domain.py
+++ b/optapy-core/tests/test_domain.py
@@ -29,8 +29,8 @@ def test_single_property():
         return [
             constraint_factory.forEach(Entity)
                               .join(Value,
-                                    [optapy.constraint.Joiners.equal(lambda entity: entity.value,
-                                                                     lambda value: value.code)])
+                                    optapy.constraint.Joiners.equal(lambda entity: entity.value,
+                                                                    lambda value: value.code))
                               .reward('Same as value', optapy.score.SimpleScore.ONE),
         ]
 
@@ -65,9 +65,9 @@ def test_single_property():
     solver_config = optapy.config.solver.SolverConfig()
     termination_config = optapy.config.solver.termination.TerminationConfig()
     termination_config.setBestScoreLimit('1')
-    solver_config.withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses(optapy.get_class(Entity)) \
-        .withConstraintProviderClass(optapy.get_class(my_constraints)) \
+    solver_config.withSolutionClass(Solution) \
+        .withEntityClasses(Entity) \
+        .withConstraintProviderClass(my_constraints) \
         .withTerminationConfig(termination_config)
     problem: Solution = Solution(Entity('A'), Value('1'), ['1', '2', '3'])
     solver = optapy.solver_factory_create(solver_config).buildSolver()
@@ -100,8 +100,8 @@ def test_tuple_group_by_key():
         return [
             constraint_factory.forEach(Entity)
                 .join(Value,
-                      [optapy.constraint.Joiners.equal(lambda entity: entity.value,
-                                                       lambda value: value.code)])
+                      optapy.constraint.Joiners.equal(lambda entity: entity.value,
+                                                      lambda value: value.code))
                 .groupBy(lambda entity, value: (0, value), optapy.constraint.ConstraintCollectors.countBi())
                 .reward('Same as value', optapy.score.SimpleScore.ONE, lambda _, count: count),
         ]
@@ -148,9 +148,9 @@ def test_tuple_group_by_key():
     solver_config = optapy.config.solver.SolverConfig()
     termination_config = optapy.config.solver.termination.TerminationConfig()
     termination_config.setBestScoreLimit(str(len(entity_list)))
-    solver_config.withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses(optapy.get_class(Entity)) \
-        .withConstraintProviderClass(optapy.get_class(my_constraints)) \
+    solver_config.withSolutionClass(Solution) \
+        .withEntityClasses(Entity) \
+        .withConstraintProviderClass(my_constraints) \
         .withTerminationConfig(termination_config)
 
     problem: Solution = Solution(entity_list,
@@ -192,18 +192,17 @@ def test_python_object():
         return [
             constraint_factory.forEach(Entity)
                 .join(Value,
-                      [optapy.constraint.Joiners.lessThanOrEqual(lambda entity: entity.value,
-                                                                 lambda value: value.code)])
+                      optapy.constraint.Joiners.lessThanOrEqual(lambda entity: entity.value,
+                                                                lambda value: value.code))
                 .reward('Same as value', optapy.score.SimpleScore.ONE),
             constraint_factory.forEach(Entity)
                 .groupBy(lambda entity: entity.value, optapy.constraint.ConstraintCollectors.count())
                 .reward('Entity have same value', optapy.score.SimpleScore.ONE, lambda value, count: count * count),
             constraint_factory.forEach(optapy.get_class(Entity))
                 .groupBy(lambda entity: (entity.code, entity.value))
-                .join(Entity, [
+                .join(Entity,
                     optapy.constraint.Joiners.equal(lambda pair: pair[0], lambda entity: entity.code),
-                    optapy.constraint.Joiners.equal(lambda pair: pair[1], lambda entity: entity.value)
-                ])
+                    optapy.constraint.Joiners.equal(lambda pair: pair[1], lambda entity: entity.value))
                 .reward('Entity for pair', optapy.score.SimpleScore.ONE),
         ]
 
@@ -264,14 +263,12 @@ def test_list_variable():
         def set_value(self, value):
             self.value = value
 
-
     def count_mismatches(entity):
         mismatches = 0
         for index in range(len(entity.value)):
             if entity.value[index] != index + 1:
                 mismatches += 1
         return mismatches
-
 
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):

--- a/optapy-core/tests/test_domain.py
+++ b/optapy-core/tests/test_domain.py
@@ -27,8 +27,8 @@ def test_single_property():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(optapy.get_class(Entity))
-                              .join(optapy.get_class(Value),
+            constraint_factory.forEach(Entity)
+                              .join(Value,
                                     [optapy.constraint.Joiners.equal(lambda entity: entity.value,
                                                                      lambda value: value.code)])
                               .reward('Same as value', optapy.score.SimpleScore.ONE),
@@ -98,8 +98,8 @@ def test_tuple_group_by_key():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(optapy.get_class(Entity))
-                .join(optapy.get_class(Value),
+            constraint_factory.forEach(Entity)
+                .join(Value,
                       [optapy.constraint.Joiners.equal(lambda entity: entity.value,
                                                        lambda value: value.code)])
                 .groupBy(lambda entity, value: (0, value), optapy.constraint.ConstraintCollectors.countBi())
@@ -190,17 +190,17 @@ def test_python_object():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(optapy.get_class(Entity))
-                .join(optapy.get_class(Value),
+            constraint_factory.forEach(Entity)
+                .join(Value,
                       [optapy.constraint.Joiners.lessThanOrEqual(lambda entity: entity.value,
                                                                  lambda value: value.code)])
                 .reward('Same as value', optapy.score.SimpleScore.ONE),
-            constraint_factory.forEach(optapy.get_class(Entity))
+            constraint_factory.forEach(Entity)
                 .groupBy(lambda entity: entity.value, optapy.constraint.ConstraintCollectors.count())
                 .reward('Entity have same value', optapy.score.SimpleScore.ONE, lambda value, count: count * count),
             constraint_factory.forEach(optapy.get_class(Entity))
                 .groupBy(lambda entity: (entity.code, entity.value))
-                .join(optapy.get_class(Entity), [
+                .join(Entity, [
                     optapy.constraint.Joiners.equal(lambda pair: pair[0], lambda entity: entity.code),
                     optapy.constraint.Joiners.equal(lambda pair: pair[1], lambda entity: entity.value)
                 ])
@@ -238,8 +238,8 @@ def test_python_object():
     termination_config = optapy.config.solver.termination.TerminationConfig()
     termination_config.setBestScoreLimit('2')
     solver_config.withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses(optapy.get_class(Entity)) \
-        .withConstraintProviderClass(optapy.get_class(my_constraints)) \
+        .withEntityClasses(Entity) \
+        .withConstraintProviderClass(my_constraints) \
         .withTerminationConfig(termination_config)
     problem: Solution = Solution(Entity('A'), Value(date1), [date1, date2, date3])
     solver = optapy.solver_factory_create(solver_config).buildSolver()
@@ -307,9 +307,9 @@ def test_list_variable():
     solver_config = optapy.config.solver.SolverConfig()
     termination_config = optapy.config.solver.termination.TerminationConfig()
     termination_config.setBestScoreLimit('0')
-    solver_config.withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses(optapy.get_class(Entity)) \
-        .withConstraintProviderClass(optapy.get_class(my_constraints)) \
+    solver_config.withSolutionClass(Solution) \
+        .withEntityClasses(Entity) \
+        .withConstraintProviderClass(my_constraints) \
         .withTerminationConfig(termination_config)
     problem: Solution = Solution(Entity('A'), [1, 2, 3])
     solver = optapy.solver_factory_create(solver_config).buildSolver()

--- a/optapy-core/tests/test_easy_score_calculator.py
+++ b/optapy-core/tests/test_easy_score_calculator.py
@@ -52,8 +52,8 @@ def test_easy_score_calculator():
     termination_config = optapy.config.solver.termination.TerminationConfig()
     termination_config.setBestScoreLimit('9')
     solver_config.withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses(optapy.get_class(Entity)) \
-        .withEasyScoreCalculatorClass(optapy.get_class(my_score_calculator)) \
+        .withEntityClasses(Entity) \
+        .withEasyScoreCalculatorClass(my_score_calculator) \
         .withTerminationConfig(termination_config)
     problem: Solution = Solution([Entity('A'), Entity('B'), Entity('C')], [1, 2, 3])
     solver = optapy.solver_factory_create(solver_config).buildSolver()

--- a/optapy-core/tests/test_incremental_score_calculator.py
+++ b/optapy-core/tests/test_incremental_score_calculator.py
@@ -143,10 +143,10 @@ def test_constraint_match_disabled_incremental_score_calculator():
     solver_config = optapy.config.solver.SolverConfig()
     termination_config = optapy.config.solver.termination.TerminationConfig()
     termination_config.setBestScoreLimit('0')
-    solver_config.withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses(optapy.get_class(Queen)) \
+    solver_config.withSolutionClass(Solution) \
+        .withEntityClasses(Queen) \
         .withScoreDirectorFactory(optapy.config.score.director.ScoreDirectorFactoryConfig() \
-                                  .withIncrementalScoreCalculatorClass(optapy.get_class(IncrementalScoreCalculator))) \
+                                  .withIncrementalScoreCalculatorClass(IncrementalScoreCalculator)) \
         .withTerminationConfig(termination_config)
     problem: Solution = Solution(4,
                                  [Queen('A', 0), Queen('B', 1), Queen('C', 2), Queen('D', 3)],
@@ -279,9 +279,9 @@ def test_constraint_match_enabled_incremental_score_calculator():
     termination_config = optapy.config.solver.termination.TerminationConfig()
     termination_config.setBestScoreLimit('0')
     solver_config.withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses(optapy.get_class(Queen)) \
+        .withEntityClasses(Queen) \
         .withScoreDirectorFactory(optapy.config.score.director.ScoreDirectorFactoryConfig() \
-                                  .withIncrementalScoreCalculatorClass(optapy.get_class(IncrementalScoreCalculator))) \
+                                  .withIncrementalScoreCalculatorClass(IncrementalScoreCalculator)) \
         .withTerminationConfig(termination_config)
     problem: Solution = Solution(4,
                                  [Queen('A', 0), Queen('B', 1), Queen('C', 2), Queen('D', 3)],

--- a/optapy-core/tests/test_inverse_relation.py
+++ b/optapy-core/tests/test_inverse_relation.py
@@ -59,7 +59,7 @@ class InverseRelationSolution:
 @optapy.constraint_provider
 def inverse_relation_constraints(constraint_factory):
     return [
-        constraint_factory.forEach(optapy.get_class(InverseRelationValue))
+        constraint_factory.forEach(InverseRelationValue)
                           .filter(lambda value: len(value.entities) > 1)
                           .penalize('Only one entity per value', optapy.score.SimpleScore.ONE)
     ]
@@ -69,9 +69,9 @@ def test_inverse_relation():
     termination = optapy.config.solver.termination.TerminationConfig()
     termination.setBestScoreLimit('0')
     solver_config = optapy.config.solver.SolverConfig() \
-        .withSolutionClass(optapy.get_class(InverseRelationSolution)) \
-        .withEntityClasses(optapy.get_class(InverseRelationEntity), optapy.get_class(InverseRelationValue)) \
-        .withConstraintProviderClass(optapy.get_class(inverse_relation_constraints)) \
+        .withSolutionClass(InverseRelationSolution) \
+        .withEntityClasses(InverseRelationEntity, InverseRelationValue) \
+        .withConstraintProviderClass(inverse_relation_constraints) \
         .withTerminationConfig(termination)
     solver = optapy.solver_factory_create(solver_config).buildSolver()
     solution = solver.solve(InverseRelationSolution(

--- a/optapy-core/tests/test_joiners.py
+++ b/optapy-core/tests/test_joiners.py
@@ -6,7 +6,6 @@ from org.optaplanner.core.api.score.stream.quad import QuadJoiner
 from org.optaplanner.core.api.score.stream.penta import PentaJoiner
 
 
-# These are tests for the workaround for https://github.com/jpype-project/jpype/issues/1016
 def test_equal_joiners_work():
     assert isinstance(Joiners.equal(), BiJoiner)
     assert isinstance(Joiners.equal(lambda a: a), BiJoiner)

--- a/optapy-core/tests/test_pinning.py
+++ b/optapy-core/tests/test_pinning.py
@@ -49,16 +49,16 @@ def test_pinning_filter():
     @optapy.constraint_provider
     def my_constraints(constraint_factory):
         return [
-            constraint_factory.forEach(optapy.get_class(Point))
+            constraint_factory.forEach(Point)
                               .penalize("Minimize Value", optapy.score.SimpleScore.ONE, lambda point: point.value)
         ]
 
     termination_config = optapy.config.solver.termination.TerminationConfig()
     termination_config.setUnimprovedSecondsSpentLimit(1)
     solver_config = optapy.config.solver.SolverConfig() \
-        .withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses(optapy.get_class(Point)) \
-        .withConstraintProviderClass(optapy.get_class(my_constraints)) \
+        .withSolutionClass(Solution) \
+        .withEntityClasses(Point) \
+        .withConstraintProviderClass(my_constraints) \
         .withTerminationConfig(termination_config)
     problem: Solution = Solution([0, 1, 2],
                                  [
@@ -121,9 +121,9 @@ def test_planning_pin():
     termination_config = optapy.config.solver.termination.TerminationConfig()
     termination_config.setUnimprovedSecondsSpentLimit(1)
     solver_config = optapy.config.solver.SolverConfig() \
-        .withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses(optapy.get_class(Point)) \
-        .withConstraintProviderClass(optapy.get_class(my_constraints)) \
+        .withSolutionClass(Solution) \
+        .withEntityClasses(Point) \
+        .withConstraintProviderClass(my_constraints) \
         .withTerminationConfig(termination_config)
     problem: Solution = Solution([0, 1, 2],
                                  [

--- a/optapy-core/tests/test_pinning.py
+++ b/optapy-core/tests/test_pinning.py
@@ -70,6 +70,7 @@ def test_pinning_filter():
     solution = solver.solve(problem)
     assert solution.get_score().getScore() == -2
 
+
 def test_planning_pin():
     @optapy.planning_entity
     class Point:
@@ -111,10 +112,11 @@ def test_planning_pin():
         def set_score(self, score):
             self.score = score
 
+
     @optapy.constraint_provider
     def my_constraints(constraint_factory):
         return [
-            constraint_factory.forEach(optapy.get_class(Point))
+            constraint_factory.forEach(Point)
                 .penalize("Minimize Value", optapy.score.SimpleScore.ONE, lambda point: point.value)
         ]
 

--- a/optapy-core/tests/test_score_manager.py
+++ b/optapy-core/tests/test_score_manager.py
@@ -25,7 +25,7 @@ class Entity:
 @optapy.constraint_provider
 def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
     return [
-        constraint_factory.forEach(optapy.get_class(Entity))
+        constraint_factory.forEach(Entity)
             .reward('Maximize Value', optapy.score.SimpleScore.ONE, lambda entity: entity.value),
     ]
 
@@ -55,9 +55,9 @@ class Solution:
 
 
 solver_config = optapy.config.solver.SolverConfig()
-solver_config.withSolutionClass(optapy.get_class(Solution)) \
-    .withEntityClasses(optapy.get_class(Entity)) \
-    .withConstraintProviderClass(optapy.get_class(my_constraints))
+solver_config.withSolutionClass(Solution) \
+    .withEntityClasses(Entity) \
+    .withConstraintProviderClass(my_constraints)
 
 
 def assert_score_manager(score_manager):

--- a/optapy-core/tests/test_solver_config.py
+++ b/optapy-core/tests/test_solver_config.py
@@ -27,8 +27,8 @@ class Value:
 @optapy.constraint_provider
 def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
     return [
-        constraint_factory.forEach(optapy.get_class(Entity))
-            .join(optapy.get_class(Value),
+        constraint_factory.forEach(Entity)
+            .join(Value,
                   [optapy.constraint.Joiners.equal(lambda entity: entity.value,
                                                    lambda value: value.code)])
             .reward('Same as value', optapy.score.SimpleScore.ONE),

--- a/optapy-core/tests/test_solver_config.py
+++ b/optapy-core/tests/test_solver_config.py
@@ -6,6 +6,7 @@ import optapy.score
 import optapy.config
 import optapy.constraint
 
+
 @optapy.planning_entity
 class Entity:
     def __init__(self, code, value=None):
@@ -19,20 +20,23 @@ class Entity:
     def set_value(self, value):
         self.value = value
 
+
 @optapy.problem_fact
 class Value:
     def __init__(self, code):
         self.code = code
+
 
 @optapy.constraint_provider
 def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
     return [
         constraint_factory.forEach(Entity)
             .join(Value,
-                  [optapy.constraint.Joiners.equal(lambda entity: entity.value,
-                                                   lambda value: value.code)])
+                  optapy.constraint.Joiners.equal(lambda entity: entity.value,
+                                                  lambda value: value.code))
             .reward('Same as value', optapy.score.SimpleScore.ONE),
     ]
+
 
 @optapy.planning_solution
 class Solution:

--- a/optapy-core/tests/test_solver_events.py
+++ b/optapy-core/tests/test_solver_events.py
@@ -21,7 +21,7 @@ def test_solver_events():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(optapy.get_class(Entity))
+            constraint_factory.forEach(Entity)
                 .reward('Maximize value', optapy.score.SimpleScore.ONE, lambda entity: entity.value),
         ]
 
@@ -52,9 +52,9 @@ def test_solver_events():
     solver_config = optapy.config.solver.SolverConfig()
     termination_config = optapy.config.solver.termination.TerminationConfig()
     termination_config.setBestScoreLimit('6')
-    solver_config.withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses(optapy.get_class(Entity)) \
-        .withConstraintProviderClass(optapy.get_class(my_constraints)) \
+    solver_config.withSolutionClass(Solution) \
+        .withEntityClasses(Entity) \
+        .withConstraintProviderClass(my_constraints) \
         .withTerminationConfig(termination_config)
 
     problem: Solution = Solution([Entity('A'), Entity('B')], [1, 2, 3])

--- a/optapy-core/tests/test_solver_manager.py
+++ b/optapy-core/tests/test_solver_manager.py
@@ -57,13 +57,13 @@ def test_solve():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(optapy.get_class(Entity))
+            constraint_factory.forEach(Entity)
                 .filter(get_lock)
                 .reward('Wait for lock', optapy.score.SimpleScore.ONE),
-            constraint_factory.forEach(optapy.get_class(Entity))
+            constraint_factory.forEach(Entity)
                 .reward('Maximize Value', optapy.score.SimpleScore.ONE, lambda entity: entity.value.value),
-            constraint_factory.forEachUniquePair(optapy.get_class(Entity),
-                                                 optapy.constraint.Joiners.equal(lambda entity: entity.value.value))
+            constraint_factory.forEachUniquePair(Entity,
+                                                 [optapy.constraint.Joiners.equal(lambda entity: entity.value.value)])
                 .penalize('Same Value', optapy.score.SimpleScore.of(12)),
         ]
 
@@ -118,9 +118,9 @@ def test_solve():
     solver_config = optapy.config.solver.SolverConfig()
     termination_config = optapy.config.solver.termination.TerminationConfig()
     termination_config.setBestScoreLimit('6')
-    solver_config.withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses(optapy.get_class(Entity)) \
-        .withConstraintProviderClass(optapy.get_class(my_constraints)) \
+    solver_config.withSolutionClass(Solution) \
+        .withEntityClasses(Entity) \
+        .withConstraintProviderClass(my_constraints) \
         .withTerminationConfig(termination_config)
     problem: Solution = Solution([Entity('A'), Entity('B'), Entity('C')], [Value(1), Value(2), Value(3)],
                                  optapy.score.SimpleScore.ONE)
@@ -190,7 +190,7 @@ def test_solve():
         lock.acquire()
         solver_job = solver_manager.solveAndListen(1, get_problem, on_best_solution_changed)
         assert_problem_change_solver_run(solver_manager, solver_job)
-        assert len(solution_list) == 2
+        assert len(solution_list) == 1
 
         solution_list = []
         lock.acquire()
@@ -202,5 +202,5 @@ def test_solve():
         lock.acquire()
         solver_job = solver_manager.solveAndListen(1, get_problem, on_best_solution_changed, on_best_solution_changed)
         assert_problem_change_solver_run(solver_manager, solver_job)
-        assert len(solution_list) == 3
+        assert len(solution_list) == 2
     time.sleep(1)  # ensure the thread factory close

--- a/optapy-core/tests/test_solver_manager.py
+++ b/optapy-core/tests/test_solver_manager.py
@@ -63,7 +63,7 @@ def test_solve():
             constraint_factory.forEach(Entity)
                 .reward('Maximize Value', optapy.score.SimpleScore.ONE, lambda entity: entity.value.value),
             constraint_factory.forEachUniquePair(Entity,
-                                                 [optapy.constraint.Joiners.equal(lambda entity: entity.value.value)])
+                                                 optapy.constraint.Joiners.equal(lambda entity: entity.value.value))
                 .penalize('Same Value', optapy.score.SimpleScore.of(12)),
         ]
 

--- a/optapy-core/tests/test_user_error.py
+++ b/optapy-core/tests/test_user_error.py
@@ -103,3 +103,26 @@ def test_bad_return_type():
     solver = optapy.solver_factory_create(solver_config).buildSolver()
     with pytest.raises(RuntimeError, match=r'An error occurred during solving. This can occur when.*'):
         solver.solve(problem)
+
+
+def test_non_proxied_class_passed():
+    class NonProxied:
+        pass
+
+    solver_config = optapy.config.solver.SolverConfig()
+    with pytest.raises(ValueError, match=re.escape(
+            f'Type {NonProxied} does not have a Java class proxy. Maybe annotate it with '
+            f'@problem_fact, @planning_entity, or @planning_solution?'
+    )):
+        solver_config.withSolutionClass(NonProxied)
+
+
+def test_non_proxied_function_passed():
+    def not_proxied():
+        pass
+
+    solver_config = optapy.config.solver.SolverConfig()
+    with pytest.raises(ValueError, match=re.escape(
+            f'Function {not_proxied} does not have a Java class proxy. Maybe annotate it with '
+            f'@constraint_provider?')):
+        solver_config.withConstraintProviderClass(not_proxied)

--- a/optapy-core/tests/test_user_error.py
+++ b/optapy-core/tests/test_user_error.py
@@ -54,8 +54,8 @@ def my_constraints(constraint_factory):
 
 def test_non_planning_solution_being_passed_to_solve():
     solver_config = optapy.config.solver.SolverConfig()
-    solver_config.withSolutionClass(optapy.get_class(Solution)).withEntityClasses(optapy.get_class(Entity)) \
-        .withConstraintProviderClass(optapy.get_class(my_constraints))
+    solver_config.withSolutionClass(Solution).withEntityClasses(Entity) \
+        .withConstraintProviderClass(my_constraints)
     solver = optapy.solver_factory_create(solver_config).buildSolver()
     with pytest.raises(ValueError, match=re.escape(
             f'A problem was not passed to solve (parameter problem was ({None})). Maybe '
@@ -82,7 +82,7 @@ def test_non_problem_fact_being_passed_to_problem_fact_collection():
 def test_none_passed_to_solve():
     solver_config = optapy.config.solver.SolverConfig()
     solver_config.withSolutionClass(optapy.get_class(Solution)).withEntityClasses(optapy.get_class(Entity)) \
-        .withConstraintProviderClass(optapy.get_class(my_constraints))
+        .withConstraintProviderClass(my_constraints)
     problem = 10
     solver = optapy.solver_factory_create(solver_config).buildSolver()
     with pytest.raises(ValueError, match=re.escape(
@@ -95,8 +95,8 @@ def test_none_passed_to_solve():
 def test_bad_return_type():
     solver_config = optapy.config.solver.SolverConfig()
     solver_config.withSolutionClass(optapy.get_class(Solution)) \
-        .withEntityClasses([optapy.get_class(Entity)]) \
-        .withConstraintProviderClass(optapy.get_class(my_constraints)) \
+        .withEntityClasses(Entity) \
+        .withConstraintProviderClass(my_constraints) \
         .withTerminationSpentLimit(optapy.types.Duration.ofSeconds(1))
 
     problem = Solution([Entity()], ['1', '2', '3'])

--- a/optapy-core/tox.ini
+++ b/optapy-core/tox.ini
@@ -9,5 +9,6 @@ envlist = py39,py310
 [testenv]
 deps =
     pytest
+    JPype1>=1.4.0
 commands =
     pytest --import-mode=importlib

--- a/optapy-docs/pom.xml
+++ b/optapy-docs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.19.0.Final</version>
+    <version>8.21.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -29,7 +29,7 @@
     -->
     <source.document.name>.index.adoc</source.document.name>
 
-    <version.optapy>8.19.0a1</version.optapy>
+    <version.optapy>8.21.0a0</version.optapy>
   </properties>
 
   <build>


### PR DESCRIPTION
Because JPype 1.4.0 fix Class conversions, get_class
is no longer required (fixes #26). Additionally,
method overloads with lambdas are fixed, so less
ambiguity errors should occur.

Known issues:

- groupBy keys using native pythons objects do not work