### PR TITLE
Support custom shadow variables

### DIFF
--- a/optapy-core/pom.xml
+++ b/optapy-core/pom.xml
@@ -16,10 +16,21 @@
     <java.module.name>org.optaplanner.optapy</java.module.name>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.ch.qos.logback>1.2.10</version.ch.qos.logback>
+    <version.io.quarkus.gizmo>1.0.11.Final</version.io.quarkus.gizmo>
 
     <version.compiler.plugin>3.8.1</version.compiler.plugin>
     <version.surefire.plugin>2.22.2</version.surefire.plugin>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkus.gizmo</groupId>
+        <artifactId>gizmo</artifactId>
+        <version>${version.io.quarkus.gizmo}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/optapy-core/src/main/java/org/optaplanner/optapy/PythonWrapperGenerator.java
+++ b/optapy-core/src/main/java/org/optaplanner/optapy/PythonWrapperGenerator.java
@@ -1,6 +1,7 @@
 package org.optaplanner.optapy;
 
 import java.io.PrintStream;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -23,6 +24,7 @@ import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.ProblemFactCollectionProperty;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.domain.variable.VariableListener;
 import org.optaplanner.core.api.function.TriFunction;
 import org.optaplanner.core.api.score.calculator.ConstraintMatchAwareIncrementalScoreCalculator;
 import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
@@ -551,6 +553,34 @@ public class PythonWrapperGenerator {
         return defineWrapperClass(className, IncrementalScoreCalculator.class, incrementalScoreCalculatorSupplier);
     }
 
+    /**
+     * Creates a class that looks like this:
+     *
+     * class PythonVariableListener implements VariableListener {
+     * public static Supplier&lt;VariableListener&gt; supplier;
+     * public final VariableListener delegate;
+     *
+     * public PythonVariableListener() {
+     * delegate = supplier.get();
+     * }
+     *
+     * public void afterVariableChange(scoreDirector, entity) {
+     *     delegate.afterVariableChange(scoreDirector, entity);
+     * }
+     * ...
+     * }
+     *
+     * @param className The simple name of the generated class
+     * @param variableListenerSupplier A supplier that returns a new instance of the variable listener on
+     *        each call
+     * @return never null
+     */
+    @SuppressWarnings("unused")
+    public static Class<?> defineVariableListenerClass(String className,
+                                                       Supplier<? extends VariableListener> variableListenerSupplier) {
+        return defineWrapperClass(className, VariableListener.class, variableListenerSupplier);
+    }
+
     /*
      * The Planning Entity, Problem Fact, and Planning Solution classes look similar, with the only
      * difference being their top-level annotation. They all look like this:
@@ -907,7 +937,13 @@ public class PythonWrapperGenerator {
         returnTypeList.add(actualReturnType);
         FieldDescriptor fieldDescriptor =
                 classCreator.getFieldCreator(methodName + "$field", actualReturnType).getFieldDescriptor();
-        MethodCreator methodCreator = classCreator.getMethodCreator(methodName, actualReturnType);
+
+        String javaMethodName = methodName;
+        if (javaMethodName.startsWith("get_") && javaMethodName.length() >= 5) {
+            javaMethodName = "get" + Character.toUpperCase(javaMethodName.charAt(4)) + javaMethodName.substring(5);
+        }
+
+        MethodCreator methodCreator = classCreator.getMethodCreator(javaMethodName, actualReturnType);
         if (signature != null) {
             methodCreator.setSignature("()" + signature);
         }
@@ -916,17 +952,7 @@ public class PythonWrapperGenerator {
         for (Map<String, Object> annotation : annotations) {
             // The class representing the annotation is in the annotationType parameter.
             AnnotationCreator annotationCreator = methodCreator.addAnnotation((Class<?>) annotation.get("annotationType"));
-            for (Method method : ((Class<?>) annotation.get("annotationType")).getMethods()) {
-                if (method.getParameterCount() != 0
-                        || !method.getDeclaringClass().equals(annotation.get("annotationType"))) {
-                    // skip if the parameter is not from the actual annotation (toString, hashCode, etc.)
-                    continue;
-                }
-                Object annotationValue = annotation.get(method.getName());
-                if (annotationValue != null) {
-                    annotationCreator.addValue(method.getName(), annotationValue);
-                }
-            }
+            createAnnotation(annotationCreator, annotation);
         }
 
         // Getter is simply: return this.field
@@ -935,7 +961,8 @@ public class PythonWrapperGenerator {
         // Assumption: all getters have a setter
         if (methodName.startsWith("get")) {
             String setterMethodName = "set" + methodName.substring(3);
-            MethodCreator setterMethodCreator = classCreator.getMethodCreator(setterMethodName, void.class, actualReturnType);
+            String javaSetterMethodName = "set" + javaMethodName.substring(3);
+            MethodCreator setterMethodCreator = classCreator.getMethodCreator(javaSetterMethodName, void.class, actualReturnType);
             if (signature != null) {
                 setterMethodCreator.setSignature("(" + signature + ")V;");
             }
@@ -954,5 +981,51 @@ public class PythonWrapperGenerator {
             setterMethodCreator.returnValue(null);
         }
         return fieldDescriptor;
+    }
+
+    private static void createAnnotation(AnnotationCreator annotationCreator, Map<String, Object> annotation) {
+        Class<?> annotationType = (Class<?>) annotation.get("annotationType");
+        for (Method method : annotationType.getMethods()) {
+            if (method.getParameterCount() != 0
+                    || !method.getDeclaringClass().equals(annotation.get("annotationType"))) {
+                // skip if the parameter is not from the actual annotation (toString, hashCode, etc.)
+                continue;
+            }
+            Object annotationValue = convertAnnotationValue(annotation.get(method.getName()));
+
+            if (annotationValue != null) {
+                annotationCreator.addValue(method.getName(), annotationValue);
+            }
+        }
+    }
+
+    private static Object convertAnnotationValue(Object annotationValue) {
+        if (annotationValue == null) {
+            return null;
+        }
+        if (annotationValue.getClass().isArray()) {
+            int arrayLength = Array.getLength(annotationValue);
+            Object[] out = new Object[arrayLength];
+            for (int i = 0; i < out.length; i++) {
+                out[i] = convertAnnotationValue(Array.get(annotationValue, i));
+            }
+            return out;
+        }
+        if (annotationValue instanceof List) {
+            List<?> annotationValueList = (List<?>) annotationValue;
+            Object[] out = new Object[annotationValueList.size()];
+            for (int i = 0; i < out.length; i++) {
+                out[i] = convertAnnotationValue(annotationValueList.get(i));
+            }
+            return out;
+        } else if (annotationValue instanceof Map) {
+            Map<String, Object> nestedAnnotation = (Map<String, Object>) annotationValue;
+            Class<?> nestedAnnotationClass = (Class<?>) nestedAnnotation.get("annotationType");
+            AnnotationCreator nestedAnnotationValue = AnnotationCreator.of(nestedAnnotationClass.getName(), RetentionPolicy.RUNTIME);
+            createAnnotation(nestedAnnotationValue, nestedAnnotation);
+            return nestedAnnotationValue;
+        } else {
+            return annotationValue;
+        }
     }
 }

--- a/optapy-core/src/main/python/optaplanner_java_interop.py
+++ b/optapy-core/src/main/python/optaplanner_java_interop.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     # These imports require a JVM to be running, so only import if type checking
     from org.optaplanner.core.api.score.stream import Constraint as _Constraint, ConstraintFactory as _ConstraintFactory
     from org.optaplanner.core.api.score.calculator import IncrementalScoreCalculator as _IncrementalScoreCalculator
+    from org.optaplanner.core.api.domain.variable import VariableListener as _VariableListener
 
 Solution_ = TypeVar('Solution_')
 ProblemId_ = TypeVar('ProblemId_')
@@ -1111,5 +1112,19 @@ def _generate_incremental_score_calculator_class(incremental_score_calculator: T
         _compose_unique_class_name(class_identifier),
         JObject(PythonSupplier(lambda: incremental_score_calculator()),
                 Supplier), constraint_match_aware)
+    class_identifier_to_java_class_map[class_identifier] = out
+    return out
+
+
+def _generate_variable_listener_class(variable_listener: Type['_VariableListener']) -> JClass:
+    from org.optaplanner.optapy import PythonWrapperGenerator  # noqa
+    from java.util.function import Supplier
+    ensure_init()
+
+    class_identifier = _get_class_identifier_for_object(variable_listener)
+    out = PythonWrapperGenerator.defineVariableListenerClass(
+        _compose_unique_class_name(class_identifier),
+        JObject(PythonSupplier(lambda: variable_listener()),
+                Supplier))
     class_identifier_to_java_class_map[class_identifier] = out
     return out

--- a/optapy-core/src/main/python/types/types.py
+++ b/optapy-core/src/main/python/types/types.py
@@ -10,7 +10,8 @@ from ..score import *
 from ..constraint import *
 
 from org.optaplanner.core.api.domain.valuerange import ValueRangeFactory, CountableValueRange, ValueRange
-from org.optaplanner.core.api.domain.variable import PlanningVariableGraphType
+from org.optaplanner.core.api.domain.variable import PlanningVariableGraphType, VariableListener
+from org.optaplanner.core.api.score.director import ScoreDirector
 from org.optaplanner.core.api.solver import Solver, SolverManager, SolverFactory, SolverJob, SolverStatus
 from org.optaplanner.core.api.solver.change import ProblemChangeDirector
 

--- a/optapy-core/tests/test_custom_shadow_variables.py
+++ b/optapy-core/tests/test_custom_shadow_variables.py
@@ -1,0 +1,112 @@
+import optapy
+import optapy.constraint
+import optapy.score
+import optapy.config
+from optapy.types import ScoreDirector
+
+
+def test_custom_shadow_variable():
+    @optapy.variable_listener
+    class MyVariableListener:
+        def afterVariableChanged(self, score_director: ScoreDirector, entity: 'MyPlanningEntity'):
+            score_director.beforeVariableChanged(entity, 'value_squared')
+            if entity.value is None:
+                entity.value_squared = None
+            else:
+                entity.value_squared = entity.value ** 2
+            score_director.afterVariableChanged(entity, 'value_squared')
+
+        def beforeVariableChanged(self, score_director: ScoreDirector, entity: 'MyPlanningEntity'):
+            pass
+
+        def beforeEntityAdded(self, score_director: ScoreDirector, entity: 'MyPlanningEntity'):
+            pass
+
+        def afterEntityAdded(self, score_director: ScoreDirector, entity: 'MyPlanningEntity'):
+            pass
+
+        def beforeEntityRemoved(self, score_director: ScoreDirector, entity: 'MyPlanningEntity'):
+            pass
+
+        def afterEntityRemoved(self, score_director: ScoreDirector, entity: 'MyPlanningEntity'):
+            pass
+
+    @optapy.planning_entity
+    class MyPlanningEntity:
+        value: int
+        value_squared: int
+
+        def __init__(self):
+            self.value = None
+            self.value_squared = None
+
+        @optapy.planning_variable(int, value_range_provider_refs=['value_range'])
+        def get_value(self):
+            return self.value
+
+        def set_value(self, new_value):
+            self.value = new_value
+
+        @optapy.custom_shadow_variable(int, variable_listener_class=MyVariableListener,
+                                       sources=[optapy.planning_variable_reference('value')])
+        def get_value_squared(self):
+            return self.value_squared
+
+        def set_value_squared(self, new_value_squared):
+            self.value_squared = new_value_squared
+
+    @optapy.constraint_provider
+    def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
+        return [
+            constraint_factory.forEach(MyPlanningEntity)
+                .filter(lambda entity: entity.value * 2 == entity.value_squared)
+                .reward('Double value is value squared', optapy.score.SimpleScore.ONE)
+        ]
+
+    @optapy.planning_solution
+    class MySolution:
+        entity_list: list[MyPlanningEntity]
+        value_list: list[int]
+        score: optapy.score.SimpleScore
+
+        def __init__(self, entity_list, value_list, score=None):
+            self.entity_list = entity_list
+            self.value_list = value_list
+            self.score = score
+
+        @optapy.planning_entity_collection_property(MyPlanningEntity)
+        def get_entity_list(self):
+            return self.entity_list
+
+        def set_entity_list(self, entity_list):
+            self.entity_list = entity_list
+
+        @optapy.problem_fact_collection_property(int)
+        @optapy.value_range_provider('value_range')
+        def get_value_list(self):
+            return self.value_list
+
+        def set_value_list(self, value_list):
+            self.value_list = value_list
+
+        @optapy.planning_score(optapy.score.SimpleScore)
+        def get_score(self):
+            return self.score
+
+        def set_score(self, score):
+            self.score = score
+
+    solver_config = optapy.config.solver.SolverConfig() \
+        .withSolutionClass(MySolution) \
+        .withEntityClasses(MyPlanningEntity) \
+        .withConstraintProviderClass(my_constraints) \
+        .withTerminationConfig(optapy.config.solver.termination.TerminationConfig()
+                               .withBestScoreLimit('1'))
+
+    solver_factory = optapy.solver_factory_create(solver_config)
+    solver = solver_factory.buildSolver()
+    problem = MySolution([MyPlanningEntity()], [1, 2, 3])
+    solution: MySolution = solver.solve(problem)
+    assert solution.score.getScore() == 1
+    assert solution.entity_list[0].value == 2
+    assert solution.entity_list[0].value_squared == 4


### PR DESCRIPTION
Generated Java classes method names
can now be potentially different from
the Python method names. In particular,
is a python method is named get_some_variable,
the Java method will be getSome_variable. This
is so users can pass in 'some_variable' instead
of '_some_variable' in ScoreDirector.

Closes #75 