### PR TITLE
Add Pythonic methods for constraint streams

### DIFF
--- a/optapy-core/src/main/python/constraint_stream.py
+++ b/optapy-core/src/main/python/constraint_stream.py
@@ -9,18 +9,25 @@ from .jpype_type_conversions import PythonFunction, PythonBiFunction, PythonTriF
 import jpype.imports  # noqa
 from jpype import JImplements, JOverride, JObject, JClass, JInt
 import inspect
-from typing import TYPE_CHECKING, Type, List, Optional, Callable
+from typing import TYPE_CHECKING, Type, Callable, Optional, overload, TypeVar, Generic, Any, Union
+
 if TYPE_CHECKING:
-    from org.optaplanner.core.api.score.stream import ConstraintFactory
-    from org.optaplanner.core.api.score.stream.uni import UniConstraintStream
-    from org.optaplanner.core.api.score.stream.bi import BiConstraintStream, BiJoiner
-    from org.optaplanner.core.api.score.stream.tri import TriConstraintStream, TriJoiner
-    from org.optaplanner.core.api.score.stream.quad import QuadConstraintStream, QuadJoiner
+    from org.optaplanner.core.api.score.stream import Constraint, ConstraintFactory
+    from org.optaplanner.core.api.score.stream.uni import UniConstraintCollector, UniConstraintStream
+    from org.optaplanner.core.api.score.stream.bi import BiJoiner, BiConstraintCollector, BiConstraintStream
+    from org.optaplanner.core.api.score.stream.tri import TriJoiner, TriConstraintCollector, TriConstraintStream
+    from org.optaplanner.core.api.score.stream.quad import QuadJoiner, QuadConstraintCollector, QuadConstraintStream
     from org.optaplanner.core.api.score.stream.penta import PentaJoiner
     from org.optaplanner.core.api.score import Score
 
+#  Class type variables
+A = TypeVar('A')
+B = TypeVar('B')
+C = TypeVar('C')
+D = TypeVar('D')
 
-def function_cast(function):
+
+def function_cast(function: A) -> A:
     arg_count = len(inspect.signature(function).parameters)
     return default_function_cast(function, arg_count)
 
@@ -40,7 +47,7 @@ def default_function_cast(function, arg_count):
         raise ValueError
 
 
-def predicate_cast(predicate):
+def predicate_cast(predicate: A) -> A:
     arg_count = len(inspect.signature(predicate).parameters)
     return default_predicate_cast(predicate, arg_count)
 
@@ -60,7 +67,7 @@ def default_predicate_cast(predicate, arg_count):
         raise ValueError
 
 
-def to_int_function_cast(function):
+def to_int_function_cast(function: A) -> A:
     arg_count = len(inspect.signature(function).parameters)
     return default_to_int_function_cast(function, arg_count)
 
@@ -154,79 +161,164 @@ def perform_group_by(delegate, package, group_by_args, *type_arguments):
             actual_group_by_args.append(group_by_args[i])
 
     if len(group_by_args) == 1:
-        return PythonUniConstraintStream(delegate.groupBy(*actual_group_by_args), package, JClass('java.lang.Object'))
+        return PythonUniConstraintStream(delegate.groupBy(*actual_group_by_args), package,
+                                             JClass('java.lang.Object'))
     elif len(group_by_args) == 2:
         return PythonBiConstraintStream(delegate.groupBy(*actual_group_by_args), package, JClass('java.lang.Object'),
-                                        JClass('java.lang.Object'))
+                                            JClass('java.lang.Object'))
     elif len(group_by_args) == 3:
         return PythonTriConstraintStream(delegate.groupBy(*actual_group_by_args), package, JClass('java.lang.Object'),
-                                         JClass('java.lang.Object'), JClass('java.lang.Object'))
+                                             JClass('java.lang.Object'), JClass('java.lang.Object'))
     elif len(group_by_args) == 4:
-        return PythonQuadConstraintStream(delegate.groupBy(*actual_group_by_args), package, JClass('java.lang.Object'),
-                                          JClass('java.lang.Object'), JClass('java.lang.Object'),
-                                          JClass('java.lang.Object'))
+        return PythonQuadConstraintStream(delegate.groupBy(*actual_group_by_args), package,
+                                              JClass('java.lang.Object'),
+                                              JClass('java.lang.Object'),
+                                              JClass('java.lang.Object'),
+                                              JClass('java.lang.Object'))
     else:
         raise ValueError
 
 
 class PythonConstraintFactory:
     delegate: 'ConstraintFactory'
+    A_ = TypeVar('A_')
+    B_ = TypeVar('B_')
+    C_ = TypeVar('C_')
+    D_ = TypeVar('D_')
+    E_ = TypeVar('E_')
 
     def __init__(self, delegate: 'ConstraintFactory'):
         self.delegate = delegate
 
-    def getDefaultConstraintPackage(self) -> str:
+    def get_default_constraint_package(self) -> str:
+        """This is ConstraintConfiguration.constraintPackage() if available, otherwise the module of the @constraint_provider function
+
+        :return:
+        """
         return self.delegate.getDefaultConstraintPackage()
 
-    def forEach(self, item_type: Type) -> 'PythonUniConstraintStream':
-        item_type = get_class(item_type)
-        return PythonUniConstraintStream(self.delegate.forEach(item_type), self.getDefaultConstraintPackage(),
-                                         item_type)
+    getDefaultConstraintPackage = get_default_constraint_package
 
-    def forEachIncludingNullVars(self, item_type: Type) -> 'PythonUniConstraintStream':
-        item_type = get_class(item_type)
-        return PythonUniConstraintStream(self.delegate.forEachIncludingNullVars(item_type),
-                                         self.getDefaultConstraintPackage(), item_type)
+    def for_each(self, source_class: Type[A_]) -> 'PythonUniConstraintStream[A_]':
+        """Start a ConstraintStream of all instances of the source_class that are known as problem facts or planning entities.
 
-    def forEachUniquePair(self, item_type: Type, *joiners: List['BiJoiner']):
-        item_type = get_class(item_type)
-        return PythonBiConstraintStream(self.delegate.forEachUniquePair(item_type,
-                                                                        extract_joiners(joiners, item_type, item_type)),
-                                        self.getDefaultConstraintPackage(), item_type, item_type)
+        :param source_class:
 
-    def from_(self, item_type: Type) -> 'PythonUniConstraintStream':
-        item_type = get_class(item_type)
-        return PythonUniConstraintStream(self.delegate.from_(item_type), self.getDefaultConstraintPackage(),
-                                         item_type)
+        :return:
+        """
+        source_class = get_class(source_class)
+        return PythonUniConstraintStream(self.delegate.forEach(source_class), self.getDefaultConstraintPackage(),
+                                             source_class)
 
-    def fromUnfiltered(self, item_type: Type) -> 'PythonUniConstraintStream':
-        item_type = get_class(item_type)
-        return PythonUniConstraintStream(self.delegate.fromUnfiltered(item_type), self.getDefaultConstraintPackage(),
-                                         item_type)
+    forEach = for_each
 
-    def fromUniquePair(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonBiConstraintStream':
-        item_type = get_class(item_type)
-        return PythonBiConstraintStream(self.delegate.fromUniquePair(item_type,
-                                                                     extract_joiners(joiners, item_type, item_type)),
-                                        self.getDefaultConstraintPackage(), item_type, item_type)
+    def for_each_including_null_vars(self, source_class: Type[A_]) -> 'PythonUniConstraintStream[A_]':
+        """Start a ConstraintStream of all instances of the source_class that are known as problem facts or planning
+        entities, without filtering of entities with null planning variables.
+
+        :param source_class:
+
+        :return:
+        """
+        source_class = get_class(source_class)
+        return PythonUniConstraintStream(self.delegate.forEachIncludingNullVars(source_class),
+                                             self.getDefaultConstraintPackage(), source_class)
+
+    forEachIncludingNullVars = for_each_including_null_vars
+
+    def for_each_unique_pair(self, source_class: Type[A_], *joiners: 'BiJoiner[A_, A_]') ->\
+            'PythonBiConstraintStream[A_, A_]':
+        """Create a new BiConstraintStream for every unique combination of A and another A with a higher @planning_id
+        that satisfies all specified joiners.
+
+        :param source_class:
+
+        :param joiners:
+
+        :return:
+        """
+        source_class = get_class(source_class)
+        return PythonBiConstraintStream(self.delegate.forEachUniquePair(source_class,
+                                                                            extract_joiners(joiners, source_class, source_class)),
+                                            self.getDefaultConstraintPackage(), source_class, source_class)
+
+    forEachUniquePair = for_each_unique_pair
+
+    def from_(self, source_class: Type[A_]) -> 'PythonUniConstraintStream[A_]':
+        """Deprecated, for removal: use for_each instead
+
+        :param source_class:
+
+        :return:
+        """
+        source_class = get_class(source_class)
+        return PythonUniConstraintStream(self.delegate.from_(source_class), self.getDefaultConstraintPackage(),
+                                             source_class)
+
+    def from_unfiltered(self, source_class: Type[A_]) -> 'PythonUniConstraintStream[A_]':
+        """Deprecated, for removal: use for_each_including_null_vars instead
+
+        :param source_class:
+
+        :return:
+        """
+        source_class = get_class(source_class)
+        return PythonUniConstraintStream(self.delegate.fromUnfiltered(source_class), self.getDefaultConstraintPackage(),
+                                             source_class)
+
+    fromUnfiltered = from_unfiltered
+
+    def from_unique_pair(self, source_class: Type[A_], *joiners: 'BiJoiner[A_, A_]') ->\
+            'PythonBiConstraintStream[A_, A_]':
+        """Deprecated, for removal: use for_each_unique_pair instead
+
+        :param source_class:
+
+        :return:
+        """
+        source_class = get_class(source_class)
+        return PythonBiConstraintStream(self.delegate.fromUniquePair(source_class,
+                                                                     extract_joiners(joiners, source_class, source_class)),
+                                        self.getDefaultConstraintPackage(), source_class, source_class)
+
+    fromUniquePair = from_unique_pair
 
 
-
-class PythonUniConstraintStream:
-    delegate: 'UniConstraintStream'
+class PythonUniConstraintStream(Generic[A]):
+    delegate: 'UniConstraintStream[A]'
     package: str
-    a_type: Type
+    a_type: Type[A]
+    A_ = TypeVar('A_')
+    B_ = TypeVar('B_')
+    C_ = TypeVar('C_')
+    D_ = TypeVar('D_')
+    E_ = TypeVar('E_')
 
-    def __init__(self, delegate: 'UniConstraintStream', package: str, a_type: Type):
+    def __init__(self, delegate: 'UniConstraintStream[A]', package: str, a_type: Type[A]):
         self.delegate = delegate
         self.package = package
         self.a_type = a_type
 
-    def filter(self, predicate) -> 'PythonUniConstraintStream':
+    def filter(self, predicate: Callable[[A], bool]) -> 'PythonUniConstraintStream[A]':
+        """Exhaustively test each fact against the predicate and match if the predicate returns True.
+
+        :param predicate:
+
+        :return:
+        """
         translated_predicate = predicate_cast(predicate)
         return PythonUniConstraintStream(self.delegate.filter(translated_predicate), self.package, self.a_type)
 
-    def join(self, unistream_or_type, *joiners: List['BiJoiner']) -> 'PythonBiConstraintStream':
+    def join(self, unistream_or_type: Union['PythonUniConstraintStream[B_]', Type[B_]], *joiners: 'BiJoiner[A, B_]') ->\
+            'PythonBiConstraintStream[A,B_]':
+        """Create a new BiConstraintStream for every combination of A and B that satisfy all specified joiners.
+
+        :param unistream_or_type:
+
+        :param joiners:
+
+        :return:
+        """
         b_type = None
         if isinstance(unistream_or_type, PythonUniConstraintStream):
             b_type = unistream_or_type.a_type
@@ -237,74 +329,288 @@ class PythonUniConstraintStream:
         join_result = self.delegate.join(unistream_or_type, extract_joiners(joiners, self.a_type, b_type))
         return PythonBiConstraintStream(join_result, self.package, self.a_type, b_type)
 
-    def ifExists(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+    def if_exists(self, item_type: Type[B_], *joiners: 'BiJoiner[A, B_]') -> 'PythonUniConstraintStream[A]':
+        """Create a new UniConstraintStream for every A where B exists that satisfy all specified joiners.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
         return PythonUniConstraintStream(self.delegate.ifExists(item_type,
                                                                 extract_joiners(joiners, self.a_type, item_type)),
-                                         self.package, self.a_type)
+                                             self.package, self.a_type)
 
-    def ifExistsIncludingNullVars(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+    ifExists = if_exists
+
+    def if_exists_including_null_vars(self, item_type: Type[B_], *joiners: 'BiJoiner[A, B_]') ->\
+            'PythonUniConstraintStream[A]':
+        """Create a new UniConstraintStream for every A where B exists that satisfy all specified joiners.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
         return PythonUniConstraintStream(self.delegate.ifExistsIncludingNullVars(item_type,
                                                                                  extract_joiners(joiners, self.a_type,
                                                                                                  item_type)),
-                                         self.package,
-                                         self.a_type)
+                                             self.package,
+                                             self.a_type)
 
-    def ifExistsOther(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+    ifExistsIncludingNullVars = if_exists_including_null_vars
+
+    def if_exists_other(self, item_type: Type[B_], *joiners: 'BiJoiner[A, B_]') -> 'PythonUniConstraintStream[A]':
+        """Create a new UniConstraintStream for every A, if another A exists that does not equal the first, and for which all specified joiners are satisfied.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
         return PythonUniConstraintStream(self.delegate.ifExistsOther(item_type, extract_joiners(joiners, self.a_type,
-                                                                                                item_type)),
-                                         self.package, self.a_type)
+                                                                                                    item_type)),
+                                             self.package, self.a_type)
 
-    def ifExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+    ifExistsOther = if_exists_other
+
+    def if_exists_other_including_null_vars(self, item_type: Type, *joiners: 'BiJoiner') -> \
+            'PythonUniConstraintStream':
         item_type = get_class(item_type)
         return PythonUniConstraintStream(self.delegate.ifExistsOtherIncludingNullVars(item_type,
-                                                                                      extract_joiners(joiners,
-                                                                                                      self.a_type,
-                                                                                                      item_type)),
-                                         self.package,
-                                         self.a_type)
+                                                                                          extract_joiners(joiners,
+                                                                                                          self.a_type,
+                                                                                                           item_type)),
+                                             self.package,
+                                             self.a_type)
 
-    def ifNotExists(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+    ifExistsOtherIncludingNullVars = if_exists_other_including_null_vars
+
+    def if_not_exists(self, item_type: Type[B_], *joiners: 'BiJoiner[A, B_]') -> 'PythonUniConstraintStream[A]':
+        """Create a new UniConstraintStream for every A where there does not exist a B where all specified joiners are satisfied.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
         return PythonUniConstraintStream(self.delegate.ifNotExists(item_type, extract_joiners(joiners, self.a_type,
-                                                                                              item_type)),
-                                         self.package, self.a_type)
+                                                                                                  item_type)),
+                                             self.package, self.a_type)
 
-    def ifNotExistsIncludingNullVars(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+    ifNotExists = if_not_exists
+
+    def if_not_exists_including_null_vars(self, item_type: Type[B_], *joiners: 'BiJoiner[A, B_]') -> \
+            'PythonUniConstraintStream[A]':
+        """Create a new UniConstraintStream for every A where there does not exist a B where all specified joiners are
+        satisfied.
+
+       :param item_type:
+
+       :param joiners:
+
+       :return:
+       """
         item_type = get_class(item_type)
         return PythonUniConstraintStream(self.delegate.ifNotExistsIncludingNullVars(item_type,
-                                                                                    extract_joiners(joiners,
-                                                                                                    self.a_type,
-                                                                                                    item_type)),
-                                         self.package,
-                                         self.a_type)
+                                                                                        extract_joiners(joiners,
+                                                                                                        self.a_type,
+                                                                                                        item_type)),
+                                             self.package,
+                                             self.a_type)
 
-    def ifNotExistsOther(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+    ifNotExistsIncludingNullVars = if_not_exists_including_null_vars
+
+    def if_not_exists_other(self, item_type: Type[B_], *joiners: 'BiJoiner[A, B_]') ->\
+            'PythonUniConstraintStream[A]':
+        """Create a new UniConstraintStream for every A where there does not exist a different A where all specified
+        joiners are satisfied.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
         return PythonUniConstraintStream(self.delegate.ifNotExistsOther(item_type, extract_joiners(joiners, self.a_type,
-                                                                                                   item_type)),
-                                         self.package,
-                                         self.a_type)
+                                                                                                       item_type)),
+                                             self.package,
+                                             self.a_type)
 
-    def ifNotExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['BiJoiner']) -> 'PythonUniConstraintStream':
+    ifNotExistsOther = if_not_exists_other
+
+    def if_not_exists_other_including_null_vars(self, item_type: Type[B_], *joiners: 'BiJoiner[A, B_]') -> \
+            'PythonUniConstraintStream[A]':
+        """Create a new UniConstraintStream for every A where there does not exist a different A where all specified
+        joiners are satisfied.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
         return PythonUniConstraintStream(self.delegate.ifNotExistsOtherIncludingNullVars(item_type,
-                                                                                         extract_joiners(joiners,
-                                                                                                         self.a_type,
-                                                                                                         item_type)),
-                                         self.package, self.a_type)
+                                                                                             extract_joiners(joiners,
+                                                                                                             self.a_type,
+                                                                                                             item_type)),
+                                             self.package, self.a_type)
 
-    def groupBy(self, *args):
+    ifNotExistsOtherIncludingNullVars = if_not_exists_other_including_null_vars
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A], A_]) -> 'PythonUniConstraintStream[A_]':
+        ...
+
+    @overload
+    def group_by(self, collector: 'UniConstraintCollector[A, Any, A_]') -> 'PythonUniConstraintStream[A_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A], A_], second_key_mapping: Callable[[A], B_]) -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A], A_], collector: 'UniConstraintCollector[A, Any, B_]') -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'UniConstraintCollector[A, Any, A_]',
+                 second_collector: 'UniConstraintCollector[A, Any, B_]') -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A], A_], second_key_mapping: Callable[[A], B_],
+                 third_key_mapping: Callable[[A], C_]) -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A], A_], second_key_mapping: Callable[[A], B_],
+                 collector: 'UniConstraintCollector[A, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A], A_], first_collector: 'UniConstraintCollector[A, Any, B_]',
+                 second_collector: 'UniConstraintCollector[A, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'UniConstraintCollector[A, Any, A_]',
+                 second_collector: 'UniConstraintCollector[A, Any, B_]',
+                 third_collector: 'UniConstraintCollector[A, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A], A_], second_key_mapping: Callable[[A], B_],
+                 third_key_mapping: Callable[[A], C_], fourth_key_mapping: Callable[[A], D_]) -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A], A_], second_key_mapping: Callable[[A], B_],
+                 third_key_mapping: Callable[[A], C_], collector: 'UniConstraintCollector[A, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A], A_], second_key_mapping: Callable[[A], B_],
+                 first_collector: 'UniConstraintCollector[A, Any, C_]',
+                 second_collector: 'UniConstraintCollector[A, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A], A_], first_collector: 'UniConstraintCollector[A, Any, B_]',
+                 second_collector: 'UniConstraintCollector[A, Any, C_]',
+                 third_collector: 'UniConstraintCollector[A, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'UniConstraintCollector[A, Any, A_]',
+                 second_collector: 'UniConstraintCollector[A, Any, B_]',
+                 third_collector: 'UniConstraintCollector[A, Any, C_]',
+                 fourth_collector: 'UniConstraintCollector[A, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    def group_by(self, *args):
+        """Collect items into groups using the group_key_function(s) and optionally aggregate the group's items into a
+        result.
+
+        The syntax of group_by is zero to four group_key functions, followed by zero to four collectors. At most
+        four arguments can be passed to group_by.
+
+        If no group_key function is passed to group_by, all items in the stream are aggregated into a single result
+        by the passed constraint collectors.
+
+        Examples:
+
+            - # count the items in this stream; returns Uni[int]
+
+              group_by(ConstraintCollectors.count())
+
+            - # count the number of shifts each employee has; returns Bi[Employee]
+
+              group_by(lambda shift: shift.employee, ConstraintCollectors.count())
+
+            - # count the number of shifts each employee has on a date; returns Tri[Employee, datetime.date, int]
+
+              group_by(lambda shift: shift.employee, lambda shift: shift.date, ConstraintCollectors.count())
+
+            - # count the number of shifts each employee has on a date; returns Tri[Employee, datetime.date, int]
+
+              group_by(lambda shift: shift.employee, lambda shift: shift.date, ConstraintCollectors.count())
+
+            - # get the dates of the first and last shift of each employee; returns Tri[Employee, datetime.date,
+              datetime.date]
+
+              group_by(lambda shift: shift.employee,
+              ConstraintCollectors.min(lambda shift: shift.date)
+              ConstraintCollectors.max(lambda shift: shift.date))
+
+        The type of stream returned depends on the number of arguments passed:
+
+        - 1 -> UniConstraintStream
+
+        - 2 -> BiConstraintStream
+
+        - 3 -> TriConstraintStream
+
+        - 4 -> QuadConstraintStream
+
+        :param args:
+
+        :return:
+        """
         return perform_group_by(self.delegate, self.package, args, self.a_type)
 
-    def map(self, mapping_function) -> 'PythonUniConstraintStream':
+    groupBy = group_by
+
+
+    def map(self, mapping_function: Callable[[A], A_]) -> 'PythonUniConstraintStream[A_]':
+        """Transforms the stream in such a way that tuples are remapped using the given function.
+
+        :param mapping_function:
+
+        :return:
+        """
         translated_function = function_cast(mapping_function)
         return PythonUniConstraintStream(self.delegate.map(translated_function), self.package,
-                                         JClass('java.lang.Object'))
+                                             JClass('java.lang.Object'))
 
-    def flattenLast(self, flattening_function) -> 'PythonUniConstraintStream':
+    def flatten_last(self, flattening_function: Callable[[A], A_]) -> 'PythonUniConstraintStream[A_]':
+        """Takes each tuple and applies a mapping on it, which turns the tuple into an Iterable.
+
+        :param flattening_function:
+
+        :return:
+        """
         def wrapped_function(last_item):
             from java.util import ArrayList
             items = flattening_function(last_item)
@@ -314,12 +620,58 @@ class PythonUniConstraintStream:
             return out
         translated_function = function_cast(wrapped_function)
         return PythonUniConstraintStream(self.delegate.flattenLast(translated_function), self.package,
-                                         JClass('java.lang.Object'))
+                                             JClass('java.lang.Object'))
 
-    def distinct(self) -> 'PythonUniConstraintStream':
+    flattenLast = flatten_last
+
+    def distinct(self) -> 'PythonUniConstraintStream[A]':
+        """Transforms the stream in such a way that all the tuples going through it are distinct.
+
+        :return:
+        """
         return PythonUniConstraintStream(self.delegate.distinct(), self.package, self.a_type)
 
-    def penalize(self, *args):
+    @overload
+    def penalize(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A], int]) -> \
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+                 match_weigher: Callable[[A], int]) -> 'Constraint':
+        ...
+
+    def penalize(self, *args) -> 'Constraint':
+        """Negatively impact the Score: subtract the constraint_weight for each match (multiplied by an optional
+        match_weigher function).
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use penalize_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - penalize(constraint_name: str, constraint_weight: Score)
+
+            - penalize(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - penalize(constraint_name: str, constraint_weight: Score, match_weigher: A -> int)
+
+            - penalize(constraint_package: str, constraint_name: str, constraint_weight: Score, match_weigher: A -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -328,22 +680,62 @@ class PythonUniConstraintStream:
             return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
                                           constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def penalizeLong(self, *args):
-        raise NotImplementedError
+    def penalize_long(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeBigDecimal(self, *args):
-        raise NotImplementedError
+    def penalize_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurable(self, *args):
-        raise NotImplementedError
+    def penalize_configurable(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurableLong(self, *args):
-        raise NotImplementedError
+    def penalize_configurable_long(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurableBigDecimal(self, *args):
-        raise NotImplementedError
+    def penalize_configurable_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def reward(self, *args):
+    @overload
+    def reward(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A], int]) -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+               match_weigher: Callable[[A], int]) -> 'Constraint':
+        ...
+
+    def reward(self, *args) -> 'Constraint':
+        """Positively impact the Score: add the constraint_weight for each match (multiplied by an optional
+        match_weigher function).
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use reward_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - reward(constraint_name: str, constraint_weight: Score)
+
+            - reward(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - reward(constraint_name: str, constraint_weight: Score, match_weigher: A -> int)
+
+            - reward(constraint_package: str, constraint_name: str, constraint_weight: Score, match_weigher: A -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -352,16 +744,58 @@ class PythonUniConstraintStream:
             return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
                                         constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def rewardLong(self, *args):
-        raise NotImplementedError
+    def reward_long(self, *args) -> 'Constraint':
+        ...
 
-    def rewardBigDecimal(self, *args):
-        raise NotImplementedError
+    def reward_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def rewardConfigurable(self, *args):
-        raise NotImplementedError
+    def reward_configurable(self, *args) -> 'Constraint':
+        ...
 
-    def impact(self, *args):
+    @overload
+    def impact(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A], int]) -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+               match_weigher: Callable[[A], int]) -> 'Constraint':
+        ...
+
+    def impact(self, *args) -> 'Constraint':
+        """Positively or negatively impact the Score: add the constraint_weight for each match
+        (multiplied by an optional match_weigher function).
+
+        Use penalize(...) or reward(...) instead, unless this constraint can both have positive and negative weights.
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use impact_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - impact(constraint_name: str, constraint_weight: Score)
+
+            - impact(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - impact(constraint_name: str, constraint_weight: Score, match_weigher: A -> int)
+
+            - impact(constraint_package: str, constraint_name: str, constraint_weight: Score, match_weigher: A -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -370,34 +804,54 @@ class PythonUniConstraintStream:
             return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
                                         constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def impactLong(self, *args):
-        raise NotImplementedError
+    def impact_long(self, *args) -> 'Constraint':
+        ...
 
-    def impactBigDecimal(self, *args):
-        raise NotImplementedError
+    def impact_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def impactConfigurable(self, *args):
-        raise NotImplementedError
+    def impact_configurable(self, *args) -> 'Constraint':
+        ...
 
 
-class PythonBiConstraintStream:
-    delegate: 'BiConstraintStream'
+class PythonBiConstraintStream(Generic[A, B]):
+    delegate: 'BiConstraintStream[A,B]'
     package: str
-    a_type: Type
-    b_type: Type
+    a_type: Type[A]
+    b_type: Type[B]
+    A_ = TypeVar('A_')
+    B_ = TypeVar('B_')
+    C_ = TypeVar('C_')
+    D_ = TypeVar('D_')
+    E_ = TypeVar('E_')
 
-    def __init__(self, delegate: 'BiConstraintStream', package: str, a_type: Type, b_type: Type):
+    def __init__(self, delegate: 'BiConstraintStream[A,B]', package: str, a_type: Type[A], b_type: Type[B]):
         self.delegate = delegate
         self.package = package
         self.a_type = a_type
         self.b_type = b_type
 
-    def filter(self, predicate) -> 'PythonBiConstraintStream':
+    def filter(self, predicate: Callable[[A,B], bool]) -> 'PythonBiConstraintStream[A,B]':
+        """Exhaustively test each fact against the predicate and match if the predicate returns True.
+
+        :param predicate:
+
+        :return:
+        """
         translated_predicate = predicate_cast(predicate)
         return PythonBiConstraintStream(self.delegate.filter(translated_predicate), self.package, self.a_type,
                                         self.b_type)
 
-    def join(self, unistream_or_type, *joiners: List['TriJoiner']) -> 'PythonTriConstraintStream':
+    def join(self, unistream_or_type: Union[PythonUniConstraintStream[C_], Type[C_]],
+             *joiners: 'TriJoiner[A,B,C_]') -> 'PythonTriConstraintStream[A,B,C_]':
+        """Create a new TriConstraintStream for every combination of A, B and C that satisfy all specified joiners.
+
+        :param unistream_or_type:
+
+        :param joiners:
+
+        :return:
+        """
         c_type = None
         if isinstance(unistream_or_type, PythonUniConstraintStream):
             c_type = unistream_or_type.a_type
@@ -408,79 +862,229 @@ class PythonBiConstraintStream:
         join_result = self.delegate.join(unistream_or_type, extract_joiners(joiners, self.a_type, self.b_type, c_type))
         return PythonTriConstraintStream(join_result, self.package, self.a_type, self.b_type, c_type)
 
-    def ifExists(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
+    def if_exists(self, item_type: Type[C_], *joiners: 'TriJoiner[A, B, C_]') -> 'PythonBiConstraintStream[A,B]':
+        """Create a new BiConstraintStream for every A, B where C exists that satisfy all specified joiners.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
         return PythonBiConstraintStream(self.delegate.ifExists(item_type,
-                                                               extract_joiners(joiners, self.a_type,
-                                                                               self.b_type, item_type)),
+                                                               extract_joiners(joiners, self.a_type, self.b_type,
+                                                                               item_type)),
                                         self.package, self.a_type, self.b_type)
 
-    def ifExistsIncludingNullVars(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
-        item_type = get_class(item_type)
-        return PythonBiConstraintStream(self.delegate.ifExistsIncludingNullVars(item_type, extract_joiners(joiners,
-                                                                                                           self.a_type,
-                                                                                                           self.b_type,
-                                                                                                           item_type)),
-                                        self.package,
-                                        self.a_type, self.b_type)
+    ifExists = if_exists
 
-    def ifExistsOther(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
-        item_type = get_class(item_type)
-        return PythonBiConstraintStream(self.delegate.ifExistsOther(item_type, extract_joiners(joiners, self.a_type,
-                                                                                               self.b_type, item_type)),
-                                        self.package, self.a_type,
-                                        self.b_type)
+    def if_exists_including_null_vars(self, item_type: Type[C_], *joiners: 'TriJoiner[A, B, C_]') ->\
+            'PythonBiConstraintStream[A,B]':
+        """Create a new BiConstraintStream for every A, B where C exists that satisfy all specified joiners.
 
-    def ifExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
-        item_type = get_class(item_type)
-        return PythonBiConstraintStream(self.delegate.ifExistsOtherIncludingNullVars(item_type,
-                                                                                     extract_joiners(joiners,
-                                                                                                     self.a_type,
-                                                                                                     self.b_type,
-                                                                                                     item_type)),
-                                        self.package, self.a_type, self.b_type)
+        :param item_type:
 
-    def ifNotExists(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
+        :param joiners:
+
+        :return:
+        """
+        item_type = get_class(item_type)
+        return PythonBiConstraintStream(self.delegate.ifExistsIncludingNullVars(item_type,
+                                                                                    extract_joiners(joiners,
+                                                                                                    self.a_type,
+                                                                                                    self.b_type,
+                                                                                                    item_type)),
+                                            self.package,
+                                            self.a_type,
+                                            self.b_type)
+
+    ifExistsIncludingNullVars = if_exists_including_null_vars
+
+    def if_not_exists(self, item_type: Type[C_], *joiners: 'TriJoiner[A, B, C_]') ->\
+            'PythonBiConstraintStream[A,B]':
+        """Create a new BiConstraintStream for every A, B, where there does not exist a C where all specified joiners
+        are satisfied.
+
+       :param item_type:
+
+       :param joiners:
+
+       :return:
+       """
         item_type = get_class(item_type)
         return PythonBiConstraintStream(self.delegate.ifNotExists(item_type, extract_joiners(joiners, self.a_type,
-                                                                                             self.b_type, item_type)),
-                                        self.package, self.a_type, self.b_type)
+                                                                                                 self.b_type,
+                                                                                                 item_type)),
+                                            self.package, self.a_type, self.b_type)
 
-    def ifNotExistsIncludingNullVars(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
+    ifNotExists = if_not_exists
+
+    def if_not_exists_including_null_vars(self, item_type: Type[C_], *joiners: 'TriJoiner[A, B, C_]') -> \
+            'PythonBiConstraintStream[A,B]':
+        """Create a new BiConstraintStream for every A, B, where there does not exist a C where all specified joiners
+        are satisfied.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
         return PythonBiConstraintStream(self.delegate.ifNotExistsIncludingNullVars(item_type,
-                                                                                   extract_joiners(joiners,
-                                                                                                   self.a_type,
-                                                                                                   self.b_type,
-                                                                                                   item_type)),
-                                        self.package, self.a_type, self.b_type)
+                                                                                       extract_joiners(joiners,
+                                                                                                       self.a_type,
+                                                                                                       self.b_type,
+                                                                                                       item_type)),
+                                            self.package,
+                                            self.a_type,
+                                            self.b_type)
 
-    def ifNotExistsOther(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
-        item_type = get_class(item_type)
-        return PythonBiConstraintStream(self.delegate.ifNotExistsOther(item_type,
-                                                                       extract_joiners(joiners,
-                                                                                       self.a_type,
-                                                                                       self.b_type,
-                                                                                       item_type)),
-                                        self.package, self.a_type, self.b_type)
+    ifNotExistsIncludingNullVars = if_not_exists_including_null_vars
 
-    def ifNotExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['TriJoiner']) -> 'PythonBiConstraintStream':
-        item_type = get_class(item_type)
-        return PythonBiConstraintStream(self.delegate.ifNotExistsOtherIncludingNullVars(item_type,
-                                                                                        extract_joiners(joiners,
-                                                                                                        self.a_type,
-                                                                                                        self.b_type,
-                                                                                                        item_type)),
-                                        self.package, self.a_type, self.b_type)
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B], A_]) -> 'PythonUniConstraintStream[A_]':
+        ...
 
-    def groupBy(self, *args):
+    @overload
+    def group_by(self, collector: 'BiConstraintCollector[A, B, Any, A_]') -> 'PythonUniConstraintStream[A_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B], A_], second_key_mapping: Callable[[A, B], B_]) -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B], A_], collector: 'BiConstraintCollector[A, B, Any, B_]') -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'BiConstraintCollector[A, B, Any, A_]',
+                 second_collector: 'BiConstraintCollector[A, B, Any, B_]') -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B], A_], second_key_mapping: Callable[[A, B], B_],
+                 third_key_mapping: Callable[[A, B], C_]) -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B], A_], second_key_mapping: Callable[[A, B], B_],
+                 collector: 'BiConstraintCollector[A, B, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B], A_], first_collector: 'BiConstraintCollector[A, B, Any, B_]',
+                 second_collector: 'BiConstraintCollector[A, B, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'BiConstraintCollector[A, B, Any, A_]',
+                 second_collector: 'BiConstraintCollector[A, B, Any, B_]',
+                 third_collector: 'BiConstraintCollector[A, B, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B], A_], second_key_mapping: Callable[[A, B], B_],
+                 third_key_mapping: Callable[[A, B], C_], fourth_key_mapping: Callable[[A, B], D_]) -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B], A_], second_key_mapping: Callable[[A, B], B_],
+                 third_key_mapping: Callable[[A, B], C_], collector: 'BiConstraintCollector[A, B, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B], A_], second_key_mapping: Callable[[A, B], B_],
+                 first_collector: 'BiConstraintCollector[A, B, Any, C_]',
+                 second_collector: 'BiConstraintCollector[A, B, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B], A_], first_collector: 'BiConstraintCollector[A, B, Any, B_]',
+                 second_collector: 'BiConstraintCollector[A, B, Any, C_]',
+                 third_collector: 'BiConstraintCollector[A, B, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'BiConstraintCollector[A, B, Any, A_]',
+                 second_collector: 'BiConstraintCollector[A, B, Any, B_]',
+                 third_collector: 'BiConstraintCollector[A, B, Any, C_]',
+                 fourth_collector: 'BiConstraintCollector[A, B, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    def group_by(self, *args):
+        """Collect items into groups using the group_key_function(s) and optionally aggregate the group's items into a
+        result.
+
+        The syntax of group_by is zero to four group_key functions, followed by zero to four collectors. At most
+        four arguments can be passed to group_by.
+
+        If no group_key function is passed to group_by, all items in the stream are aggregated into a single result
+        by the passed constraint collectors.
+
+        Examples:
+
+            - # count the items in this stream; returns Uni[int]
+
+              group_by(ConstraintCollectors.count_bi())
+
+            - # count the number of shifts each employee has; returns Bi[Employee]
+
+              group_by(lambda shift, _: shift.employee, ConstraintCollectors.count_bi())
+
+            - # count the number of shifts each employee has on a date; returns Tri[Employee, datetime.date, int]
+
+              group_by(lambda shift, _: shift.employee, lambda shift, _: shift.date, ConstraintCollectors.count_bi())
+
+            - # count the number of shifts each employee has on a date; returns Tri[Employee, datetime.date, int]
+
+              group_by(lambda shift, _: shift.employee, lambda shift, _: shift.date, ConstraintCollectors.count_bi())
+
+            - # get the dates of the first and last shift of each employee; returns Tri[Employee, datetime.date,
+              datetime.date]
+
+              group_by(lambda shift, _: shift.employee,
+              ConstraintCollectors.min(lambda shift, _: shift.date)
+              ConstraintCollectors.max(lambda shift, _: shift.date))
+
+        The type of stream returned depends on the number of arguments passed:
+
+        - 1 -> UniConstraintStream
+
+        - 2 -> BiConstraintStream
+
+        - 3 -> TriConstraintStream
+
+        - 4 -> QuadConstraintStream
+
+        :param args:
+
+        :return:
+        """
         return perform_group_by(self.delegate, self.package, args, self.a_type, self.b_type)
 
-    def map(self, mapping_function) -> 'PythonUniConstraintStream':
-        translated_function = function_cast(mapping_function)
-        return PythonUniConstraintStream(self.delegate.map(translated_function), self.package, JClass('java.lang.Object'))
+    groupBy = group_by
 
-    def flattenLast(self, flattening_function) -> 'PythonBiConstraintStream':
+    def map(self, mapping_function: Callable[[A,B],A_]) -> 'PythonUniConstraintStream[A_]':
+        """Transforms the stream in such a way that tuples are remapped using the given function.
+
+        :param mapping_function:
+
+        :return:
+        """
+        translated_function = function_cast(mapping_function)
+        return PythonUniConstraintStream(self.delegate.map(translated_function), self.package,
+                                             JClass('java.lang.Object'))
+
+    def flatten_last(self, flattening_function: Callable[[B], B_]) -> 'PythonBiConstraintStream[A,B_]':
+        """Takes each tuple and applies a mapping on it, which turns the tuple into an Iterable.
+
+        :param flattening_function:
+
+        :return:
+        """
         def wrapped_function(last_item):
             from java.util import ArrayList
             items = flattening_function(last_item)
@@ -491,12 +1095,59 @@ class PythonBiConstraintStream:
 
         translated_function = function_cast(wrapped_function)
         return PythonBiConstraintStream(self.delegate.flattenLast(translated_function), self.package,
-                                        self.a_type, JClass('java.lang.Object'))
+                                            JClass('java.lang.Object'), JClass('java.lang.Object'))
 
-    def distinct(self) -> 'PythonBiConstraintStream':
+    flattenLast = flatten_last
+
+    def distinct(self) -> 'PythonBiConstraintStream[A,B]':
+        """Transforms the stream in such a way that all the tuples going through it are distinct.
+
+        :return:
+        """
         return PythonBiConstraintStream(self.delegate.distinct(), self.package, self.a_type, self.b_type)
 
-    def penalize(self, *args):
+    @overload
+    def penalize(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A, B], int]) ->\
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+                 match_weigher: Callable[[A, B], int]) -> 'Constraint':
+        ...
+
+    def penalize(self, *args) -> 'Constraint':
+        """Negatively impact the Score: subtract the constraint_weight for each match (multiplied by an optional
+        match_weigher function).
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use penalize_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - penalize(constraint_name: str, constraint_weight: Score)
+
+            - penalize(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - penalize(constraint_name: str, constraint_weight: Score, match_weigher: (A, B) -> int)
+
+            - penalize(constraint_package: str, constraint_name: str, constraint_weight: Score,
+              match_weigher: (A, B) -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -505,22 +1156,63 @@ class PythonBiConstraintStream:
             return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
                                           constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def penalizeLong(self, *args):
-        raise NotImplementedError
+    def penalize_long(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeBigDecimal(self, *args):
-        raise NotImplementedError
+    def penalize_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurable(self, *args):
-        raise NotImplementedError
+    def penalize_configurable(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurableLong(self, *args):
-        raise NotImplementedError
+    def penalize_configurable_long(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurableBigDecimal(self, *args):
-        raise NotImplementedError
+    def penalize_configurable_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def reward(self, *args):
+    @overload
+    def reward(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A, B], int]) -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+                 match_weigher: Callable[[A, B], int]) -> 'Constraint':
+        ...
+
+    def reward(self, *args) -> 'Constraint':
+        """Positively impact the Score: add the constraint_weight for each match (multiplied by an optional
+        match_weigher function).
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use reward_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - reward(constraint_name: str, constraint_weight: Score)
+
+            - reward(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - reward(constraint_name: str, constraint_weight: Score, match_weigher: (A, B) -> int)
+
+            - reward(constraint_package: str, constraint_name: str, constraint_weight: Score,
+              match_weigher: (A, B) -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -529,16 +1221,59 @@ class PythonBiConstraintStream:
             return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
                                         constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def rewardLong(self, *args):
-        raise NotImplementedError
+    def reward_long(self, *args) -> 'Constraint':
+        ...
 
-    def rewardBigDecimal(self, *args):
-        raise NotImplementedError
+    def reward_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def rewardConfigurable(self, *args):
-        raise NotImplementedError
+    def reward_configurable(self, *args) -> 'Constraint':
+        ...
 
-    def impact(self, *args):
+    @overload
+    def impact(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A, B], int]) -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+               match_weigher: Callable[[A, B], int]) -> 'Constraint':
+        ...
+
+    def impact(self, *args) -> 'Constraint':
+        """Positively or negatively impact the Score: add the constraint_weight for each match
+        (multiplied by an optional match_weigher function).
+
+        Use penalize(...) or reward(...) instead, unless this constraint can both have positive and negative weights.
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use impact_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - impact(constraint_name: str, constraint_weight: Score)
+
+            - impact(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - impact(constraint_name: str, constraint_weight: Score, match_weigher: (A, B) -> int)
+
+            - impact(constraint_package: str, constraint_name: str, constraint_weight: Score,
+              match_weigher: (A, B) -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -547,36 +1282,57 @@ class PythonBiConstraintStream:
             return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
                                         constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def impactLong(self, *args):
-        raise NotImplementedError
+    def impact_long(self, *args) -> 'Constraint':
+        ...
 
-    def impactBigDecimal(self, *args):
-        raise NotImplementedError
+    def impact_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def impactConfigurable(self, *args):
-        raise NotImplementedError
+    def impact_configurable(self, *args) -> 'Constraint':
+        ...
 
 
-class PythonTriConstraintStream:
-    delegate: 'TriConstraintStream'
+class PythonTriConstraintStream(Generic[A, B, C]):
+    delegate: 'TriConstraintStream[A,B,C]'
     package: str
-    a_type: Type
-    b_type: Type
-    c_type: Type
+    a_type: Type[A]
+    b_type: Type[B]
+    c_type: Type[C]
+    A_ = TypeVar('A_')
+    B_ = TypeVar('B_')
+    C_ = TypeVar('C_')
+    D_ = TypeVar('D_')
+    E_ = TypeVar('E_')
 
-    def __init__(self, delegate: 'TriConstraintStream', package: str, a_type: Type, b_type: Type, c_type: Type):
+    def __init__(self, delegate: 'TriConstraintStream[A,B,C]', package: str, a_type: Type[A], b_type: Type[B],
+                 c_type: Type[C]):
         self.delegate = delegate
         self.package = package
         self.a_type = a_type
         self.b_type = b_type
         self.c_type = c_type
 
-    def filter(self, predicate) -> 'PythonTriConstraintStream':
+    def filter(self, predicate: Callable[[A, B, C], bool]) -> 'PythonTriConstraintStream[A,B,C]':
+        """Exhaustively test each fact against the predicate and match if the predicate returns True.
+
+        :param predicate:
+
+        :return:
+        """
         translated_predicate = predicate_cast(predicate)
         return PythonTriConstraintStream(self.delegate.filter(translated_predicate), self.package, self.a_type,
-                                         self.b_type, self.c_type)
+                                             self.b_type, self.c_type)
 
-    def join(self, unistream_or_type, *joiners: List['QuadJoiner']) -> 'PythonQuadConstraintStream':
+    def join(self, unistream_or_type: Union[PythonUniConstraintStream[D_], Type[D_]],
+             *joiners: 'QuadJoiner[A, B, C, D_]') -> 'PythonQuadConstraintStream[A,B,C,D_]':
+        """Create a new QuadConstraintStream for every combination of A, B and C that satisfy all specified joiners.
+
+        :param unistream_or_type:
+
+        :param joiners:
+
+        :return:
+        """
         d_type = None
         if isinstance(unistream_or_type, PythonUniConstraintStream):
             d_type = unistream_or_type.a_type
@@ -588,91 +1344,239 @@ class PythonTriConstraintStream:
                                                                             self.c_type, d_type))
         return PythonQuadConstraintStream(join_result, self.package, self.a_type, self.b_type, self.c_type, d_type)
 
-    def ifExists(self, item_type: Type, *joiners: List['QuadJoiner']) -> 'PythonTriConstraintStream':
-        item_type = get_class(item_type)
-        return PythonTriConstraintStream(self.delegate.ifExists(item_type, extract_joiners(joiners, self.a_type,
-                                                                                           self.b_type, self.c_type,
-                                                                                           item_type)), self.package,
-                                         self.a_type, self.b_type, self.c_type)
+    def if_exists(self, item_type: Type[D_], *joiners: 'QuadJoiner[A, B, C, D_]') ->\
+            'PythonTriConstraintStream[A,B,C]':
+        """Create a new TriConstraintStream for every A, B, C where D exists that satisfy all specified joiners.
 
-    def ifExistsIncludingNullVars(self, item_type: Type, *joiners: List['QuadJoiner']) -> 'PythonTriConstraintStream':
-        item_type = get_class(item_type)
-        return PythonTriConstraintStream(self.delegate.ifExistsIncludingNullVars(item_type, extract_joiners(joiners,
-                                                                                                            self.a_type,
-                                                                                                            self.b_type,
-                                                                                                            self.c_type,
-                                                                                                            item_type)),
-                                         self.package, self.a_type, self.b_type, self.c_type)
+        :param item_type:
 
-    def ifExistsOther(self, item_type: Type, *joiners: List['QuadJoiner']) -> 'PythonTriConstraintStream':
-        item_type = get_class(item_type)
-        return PythonTriConstraintStream(self.delegate.ifExistsOther(item_type, extract_joiners(joiners,
-                                                                                                self.a_type,
-                                                                                                self.b_type,
-                                                                                                self.c_type,
-                                                                                                item_type)),
-                                         self.package, self.a_type, self.b_type, self.c_type)
+        :param joiners:
 
-    def ifExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['QuadJoiner']) \
-            -> 'PythonTriConstraintStream':
+        :return:
+        """
         item_type = get_class(item_type)
-        return PythonTriConstraintStream(self.delegate.ifExistsOtherIncludingNullVars(item_type,
-                                                                                      extract_joiners(joiners,
-                                                                                                      self.a_type,
-                                                                                                      self.b_type,
-                                                                                                      self.c_type,
-                                                                                                      item_type)),
-                                         self.package, self.a_type, self.b_type, self.c_type)
+        return PythonTriConstraintStream(self.delegate.ifExists(item_type,
+                                                                    extract_joiners(joiners, self.a_type,
+                                                                                    self.b_type,
+                                                                                    self.c_type,
+                                                                                    item_type)),
+                                             self.package, self.a_type, self.b_type, self.c_type)
 
-    def ifNotExists(self, item_type: Type, *joiners: List['QuadJoiner']) -> 'PythonTriConstraintStream':
+    ifExists = if_exists
+
+    def if_exists_including_null_vars(self, item_type: Type[D_], *joiners: 'QuadJoiner[A, B, C, D_]') ->\
+            'PythonTriConstraintStream[A,B,C]':
+        """Create a new TriConstraintStream for every A, B where D exists that satisfy all specified joiners.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
-        return PythonTriConstraintStream(self.delegate.ifNotExists(item_type, extract_joiners(joiners,
-                                                                                              self.a_type,
-                                                                                              self.b_type,
-                                                                                              self.c_type,
-                                                                                              item_type)),
-                                         self.package, self.a_type, self.b_type, self.c_type)
+        return PythonTriConstraintStream(self.delegate.ifExistsIncludingNullVars(item_type,
+                                                                                     extract_joiners(joiners,
+                                                                                                     self.a_type,
+                                                                                                     self.b_type,
+                                                                                                     self.c_type,
+                                                                                                     item_type)),
+                                             self.package,
+                                             self.a_type,
+                                             self.b_type,
+                                             self.c_type)
 
-    def ifNotExistsIncludingNullVars(self, item_type: Type, *joiners: List['QuadJoiner']) \
-            -> 'PythonTriConstraintStream':
+    ifExistsIncludingNullVars = if_exists_including_null_vars
+
+    def if_not_exists(self, item_type: Type[D_], *joiners: 'QuadJoiner[A, B, C, D_]') ->\
+            'PythonTriConstraintStream[A,B,C]':
+        """Create a new TriConstraintStream for every A, B, C where there does not exist a D where all specified joiners
+        are satisfied.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
+        item_type = get_class(item_type)
+        return PythonTriConstraintStream(self.delegate.ifNotExists(item_type, extract_joiners(joiners, self.a_type,
+                                                                                                  self.b_type,
+                                                                                                  self.c_type,
+                                                                                                  item_type)),
+                                             self.package, self.a_type, self.b_type, self.c_type)
+
+    ifNotExists = if_not_exists
+
+    def if_not_exists_including_null_vars(self, item_type: Type[D_], *joiners: 'QuadJoiner[A, B, C, D_]') -> \
+            'PythonTriConstraintStream[A,B,C]':
+        """Create a new TriConstraintStream for every A, B, C where there does not exist a D where all specified joiners
+        are satisfied.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
         return PythonTriConstraintStream(self.delegate.ifNotExistsIncludingNullVars(item_type,
-                                                                                    extract_joiners(joiners,
-                                                                                                    self.a_type,
-                                                                                                    self.b_type,
-                                                                                                    self.c_type,
-                                                                                                    item_type)),
-                                         self.package, self.a_type, self.b_type, self.c_type)
+                                                                                        extract_joiners(joiners,
+                                                                                                        self.a_type,
+                                                                                                        self.b_type,
+                                                                                                        self.c_type,
+                                                                                                        item_type)),
+                                             self.package,
+                                             self.a_type,
+                                             self.b_type,
+                                             self.c_type)
 
-    def ifNotExistsOther(self, item_type: Type, *joiners: List['QuadJoiner']) -> 'PythonTriConstraintStream':
-        item_type = get_class(item_type)
-        return PythonTriConstraintStream(self.delegate.ifNotExistsOther(item_type, extract_joiners(joiners,
-                                                                                                   self.a_type,
-                                                                                                   self.b_type,
-                                                                                                   self.c_type,
-                                                                                                   item_type)),
-                                         self.package, self.a_type, self.b_type, self.c_type)
+    ifNotExistsIncludingNullVars = if_not_exists_including_null_vars
 
-    def ifNotExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['QuadJoiner']) \
-            -> 'PythonTriConstraintStream':
-        item_type = get_class(item_type)
-        return PythonTriConstraintStream(self.delegate.ifNotExistsOtherIncludingNullVars(item_type,
-                                                                                         extract_joiners(joiners,
-                                                                                                         self.a_type,
-                                                                                                         self.b_type,
-                                                                                                         self.c_type,
-                                                                                                         item_type)),
-                                         self.package, self.a_type, self.b_type, self.c_type)
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B, C], A_]) -> 'PythonUniConstraintStream[A_]':
+        ...
 
-    def groupBy(self, *args):
+    @overload
+    def group_by(self, collector: 'TriConstraintCollector[A, B, C, Any, A_]') -> 'PythonUniConstraintStream[A_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C], A_], second_key_mapping: Callable[[A, B, C], B_]) -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B, C], A_], collector: 'TriConstraintCollector[A, B, C, Any, B_]') -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'TriConstraintCollector[A, B, C, Any, A_]',
+                 second_collector: 'TriConstraintCollector[A, B, C, Any, B_]') -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C], A_], second_key_mapping: Callable[[A, B, C], B_],
+                 third_key_mapping: Callable[[A, B, C], C_]) -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C], A_], second_key_mapping: Callable[[A, B, C], B_],
+                 collector: 'TriConstraintCollector[A, B, C, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B, C], A_], first_collector: 'TriConstraintCollector[A, B, C, Any, B_]',
+                 second_collector: 'TriConstraintCollector[A, B, C, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'TriConstraintCollector[A, B, C, Any, A_]',
+                 second_collector: 'TriConstraintCollector[A, B, C, Any, B_]',
+                 third_collector: 'TriConstraintCollector[A, B, C, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C], A_], second_key_mapping: Callable[[A, B, C], B_],
+                 third_key_mapping: Callable[[A, B, C], C_], fourth_key_mapping: Callable[[A, B, C], D_]) -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C], A_], second_key_mapping: Callable[[A, B, C], B_],
+                 third_key_mapping: Callable[[A, B, C], C_], collector: 'TriConstraintCollector[A, B, C, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C], A_], second_key_mapping: Callable[[A, B, C], B_],
+                 first_collector: 'TriConstraintCollector[A, B, C, Any, C_]',
+                 second_collector: 'TriConstraintCollector[A, B, C, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B, C], A_], first_collector: 'TriConstraintCollector[A, B, C, Any, B_]',
+                 second_collector: 'TriConstraintCollector[A, B, C, Any, C_]',
+                 third_collector: 'TriConstraintCollector[A, B, C, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'TriConstraintCollector[A, B, C, Any, A_]',
+                 second_collector: 'TriConstraintCollector[A, B, C, Any, B_]',
+                 third_collector: 'TriConstraintCollector[A, B, C, Any, C_]',
+                 fourth_collector: 'TriConstraintCollector[A, B, C, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    def group_by(self, *args):
+        """Collect items into groups using the group_key_function(s) and optionally aggregate the group's items into a
+        result.
+
+        The syntax of group_by is zero to four group_key functions, followed by zero to four collectors. At most
+        four arguments can be passed to group_by.
+
+        If no group_key function is passed to group_by, all items in the stream are aggregated into a single result
+        by the passed constraint collectors.
+
+        Examples:
+
+            - # count the items in this stream; returns Uni[int]
+
+              group_by(ConstraintCollectors.count_tri())
+
+            - # count the number of shifts each employee has; returns Bi[Employee]
+
+              group_by(lambda shift, _, _: shift.employee, ConstraintCollectors.count_tri())
+
+            - # count the number of shifts each employee has on a date; returns Tri[Employee, datetime.date, int]
+
+              group_by(lambda shift, _, _: shift.employee, lambda shift, _, _: shift.date,
+              ConstraintCollectors.count_tri())
+
+            - # count the number of shifts each employee has on a date; returns Tri[Employee, datetime.date, int]
+
+              group_by(lambda shift, _, _: shift.employee, lambda shift, _, _: shift.date,
+              ConstraintCollectors.count_tri())
+
+            - # get the dates of the first and last shift of each employee; returns Tri[Employee, datetime.date,
+              datetime.date]
+
+              group_by(lambda shift, _, _: shift.employee,
+              ConstraintCollectors.min(lambda shift, _, _: shift.date)
+              ConstraintCollectors.max(lambda shift, _, _: shift.date))
+
+        The type of stream returned depends on the number of arguments passed:
+
+        - 1 -> UniConstraintStream
+
+        - 2 -> BiConstraintStream
+
+        - 3 -> TriConstraintStream
+
+        - 4 -> QuadConstraintStream
+
+        :param args:
+
+        :return:
+        """
         return perform_group_by(self.delegate, self.package, args, self.a_type, self.b_type, self.c_type)
 
-    def map(self, mapping_function) -> 'PythonUniConstraintStream':
+    groupBy = group_by
+
+    def map(self, mapping_function: Callable[[A,B,C], A_]) -> 'PythonUniConstraintStream[A_]':
+        """Transforms the stream in such a way that tuples are remapped using the given function.
+
+        :param mapping_function:
+
+        :return:
+        """
         translated_function = function_cast(mapping_function)
         return PythonUniConstraintStream(self.delegate.map(translated_function), self.package,
-                                         JClass('java.lang.Object'))
+                                             JClass('java.lang.Object'))
 
-    def flattenLast(self, flattening_function) -> 'PythonTriConstraintStream':
+    def flatten_last(self, flattening_function: Callable[[C], C_]) -> 'PythonTriConstraintStream[A,B,C_]':
+        """Takes each tuple and applies a mapping on it, which turns the tuple into an Iterable.
+
+        :param flattening_function:
+
+        :return:
+        """
         def wrapped_function(last_item):
             from java.util import ArrayList
             items = flattening_function(last_item)
@@ -680,15 +1584,64 @@ class PythonTriConstraintStream:
             for item in items:
                 out.add(item)
             return out
+
         translated_function = function_cast(wrapped_function)
         return PythonTriConstraintStream(self.delegate.flattenLast(translated_function), self.package,
-                                         self.a_type, self.b_type, JClass('java.lang.Object'))
+                                             JClass('java.lang.Object'), JClass('java.lang.Object'),
+                                             JClass('java.lang.Object'))
 
-    def distinct(self) -> 'PythonTriConstraintStream':
-        return PythonTriConstraintStream(self.delegate.distinct(), self.package, self.a_type,
-                                         self.b_type, self.c_type)
+    flattenLast = flatten_last
 
-    def penalize(self, *args):
+    def distinct(self) -> 'PythonTriConstraintStream[A, B, C]':
+        """Transforms the stream in such a way that all the tuples going through it are distinct.
+
+        :return:
+        """
+        return PythonTriConstraintStream(self.delegate.distinct(), self.package, self.a_type, self.b_type,
+                                             self.c_type)
+
+    @overload
+    def penalize(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A, B, C], int]) -> \
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+                 match_weigher: Callable[[A, B, C], int]) -> 'Constraint':
+        ...
+
+    def penalize(self, *args) -> 'Constraint':
+        """Negatively impact the Score: subtract the constraint_weight for each match (multiplied by an optional
+        match_weigher function).
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use penalize_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - penalize(constraint_name: str, constraint_weight: Score)
+
+            - penalize(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - penalize(constraint_name: str, constraint_weight: Score, match_weigher: (A, B, C) -> int)
+
+            - penalize(constraint_package: str, constraint_name: str, constraint_weight: Score,
+              match_weigher: (A, B, C) -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -697,22 +1650,63 @@ class PythonTriConstraintStream:
             return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
                                           constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def penalizeLong(self, *args):
-        raise NotImplementedError
+    def penalize_long(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeBigDecimal(self, *args):
-        raise NotImplementedError
+    def penalize_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurable(self, *args):
-        raise NotImplementedError
+    def penalize_configurable(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurableLong(self, *args):
-        raise NotImplementedError
+    def penalize_configurable_long(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurableBigDecimal(self, *args):
-        raise NotImplementedError
+    def penalize_configurable_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def reward(self, *args):
+    @overload
+    def reward(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A, B, C], int]) -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+               match_weigher: Callable[[A, B, C], int]) -> 'Constraint':
+        ...
+
+    def reward(self, *args) -> 'Constraint':
+        """Positively impact the Score: add the constraint_weight for each match (multiplied by an optional
+        match_weigher function).
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use reward_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - reward(constraint_name: str, constraint_weight: Score)
+
+            - reward(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - reward(constraint_name: str, constraint_weight: Score, match_weigher: (A, B, C) -> int)
+
+            - reward(constraint_package: str, constraint_name: str, constraint_weight: Score,
+              match_weigher: (A, B, C) -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -721,16 +1715,59 @@ class PythonTriConstraintStream:
             return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
                                         constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def rewardLong(self, *args):
-        raise NotImplementedError
+    def reward_long(self, *args) -> 'Constraint':
+        ...
 
-    def rewardBigDecimal(self, *args):
-        raise NotImplementedError
+    def reward_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def rewardConfigurable(self, *args):
-        raise NotImplementedError
+    def reward_configurable(self, *args) -> 'Constraint':
+        ...
 
-    def impact(self, *args):
+    @overload
+    def impact(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A, B, C], int]) -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+               match_weigher: Callable[[A, B, C], int]) -> 'Constraint':
+        ...
+
+    def impact(self, *args) -> 'Constraint':
+        """Positively or negatively impact the Score: add the constraint_weight for each match
+        (multiplied by an optional match_weigher function).
+
+        Use penalize(...) or reward(...) instead, unless this constraint can both have positive and negative weights.
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use impact_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - impact(constraint_name: str, constraint_weight: Score)
+
+            - impact(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - impact(constraint_name: str, constraint_weight: Score, match_weigher: (A, B, C) -> int)
+
+            - impact(constraint_package: str, constraint_name: str, constraint_weight: Score,
+              match_weigher: (A, B, C) -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -739,26 +1776,31 @@ class PythonTriConstraintStream:
             return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
                                         constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def impactLong(self, *args):
-        raise NotImplementedError
+    def impact_long(self, *args) -> 'Constraint':
+        ...
 
-    def impactBigDecimal(self, *args):
-        raise NotImplementedError
+    def impact_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def impactConfigurable(self, *args):
-        raise NotImplementedError
+    def impact_configurable(self, *args) -> 'Constraint':
+        ...
 
 
-class PythonQuadConstraintStream:
-    delegate: 'QuadConstraintStream'
+class PythonQuadConstraintStream(Generic[A, B, C, D]):
+    delegate: 'QuadConstraintStream[A,B,C,D]'
     package: str
-    a_type: Type
-    b_type: Type
-    c_type: Type
-    d_type: Type
+    a_type: Type[A]
+    b_type: Type[B]
+    c_type: Type[C]
+    d_type: Type[D]
+    A_ = TypeVar('A_')
+    B_ = TypeVar('B_')
+    C_ = TypeVar('C_')
+    D_ = TypeVar('D_')
+    E_ = TypeVar('E_')
 
-    def __init__(self, delegate: 'QuadConstraintStream', package: str, a_type: Type, b_type: Type, c_type: Type,
-                 d_type: type):
+    def __init__(self, delegate: 'QuadConstraintStream[A,B,C,D]', package: str, a_type: Type[A], b_type: Type[B],
+                 c_type: Type[C], d_type: Type[D]):
         self.delegate = delegate
         self.package = package
         self.a_type = a_type
@@ -766,107 +1808,255 @@ class PythonQuadConstraintStream:
         self.c_type = c_type
         self.d_type = d_type
 
-    def filter(self, predicate) -> 'PythonQuadConstraintStream':
+    def filter(self, predicate: Callable[[A,B,C,D], bool]) -> 'PythonQuadConstraintStream[A,B,C,D]':
+        """Exhaustively test each fact against the predicate and match if the predicate returns True.
+
+        :param predicate:
+
+        :return:
+        """
         translated_predicate = predicate_cast(predicate)
         return PythonQuadConstraintStream(self.delegate.filter(translated_predicate), self.package, self.a_type,
-                                          self.b_type, self.c_type, self.d_type)
+                                              self.b_type, self.c_type, self.d_type)
 
-    def ifExists(self, item_type: Type, *joiners: List['PentaJoiner']) -> 'PythonQuadConstraintStream':
+    def if_exists(self, item_type: Type[E_], *joiners: 'PentaJoiner[A, B, C, D, E_]') ->\
+            'PythonQuadConstraintStream[A,B,C,D]':
+        """Create a new QuadConstraintStream for every A, B, C, D where E exists that satisfy all specified joiners.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
-        return PythonQuadConstraintStream(self.delegate.ifExists(item_type, extract_joiners(joiners,
-                                                                                            self.a_type,
-                                                                                            self.b_type,
-                                                                                            self.c_type,
-                                                                                            self.d_type,
-                                                                                            item_type)),
-                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+        return PythonQuadConstraintStream(self.delegate.ifExists(item_type,
+                                                                     extract_joiners(joiners, self.a_type,
+                                                                                     self.b_type,
+                                                                                     self.c_type,
+                                                                                     self.d_type,
+                                                                                     item_type)),
+                                              self.package, self.a_type, self.b_type, self.c_type, self.d_type)
 
-    def ifExistsIncludingNullVars(self, item_type: Type, *joiners: List['PentaJoiner']) -> 'PythonQuadConstraintStream':
+    ifExists = if_exists
+
+    def if_exists_including_null_vars(self, item_type: Type[E_], *joiners: 'PentaJoiner[A, B, C, D, E_]') ->\
+            'PythonQuadConstraintStream[A,B,C,D]':
+        """Create a new QuadConstraintStream for every A, B, C, D where E exists that satisfy all specified joiners.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
         return PythonQuadConstraintStream(self.delegate.ifExistsIncludingNullVars(item_type,
-                                                                                  extract_joiners(joiners,
-                                                                                                  self.a_type,
-                                                                                                  self.b_type,
-                                                                                                  self.c_type,
-                                                                                                  self.d_type,
-                                                                                                  item_type)),
-                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+                                                                                      extract_joiners(joiners,
+                                                                                                      self.a_type,
+                                                                                                      self.b_type,
+                                                                                                      self.c_type,
+                                                                                                      self.d_type,
+                                                                                                      item_type)),
+                                              self.package,
+                                              self.a_type,
+                                              self.b_type,
+                                              self.c_type,
+                                              self.d_type)
 
-    def ifExistsOther(self, item_type: Type, *joiners: List['PentaJoiner']) -> 'PythonQuadConstraintStream':
+    ifExistsIncludingNullVars = if_exists_including_null_vars
+
+    def if_not_exists(self, item_type: Type[E_], *joiners: 'PentaJoiner[A, B, C, D, E_]') ->\
+            'PythonQuadConstraintStream[A,B,C,D]':
+        """Create a new QuadConstraintStream for every A, B, C, D where there does not exist an E where all specified
+        joiners are satisfied.
+
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
-        return PythonQuadConstraintStream(self.delegate.ifExistsOther(item_type, extract_joiners(joiners,
-                                                                                                 self.a_type,
-                                                                                                 self.b_type,
-                                                                                                 self.c_type,
-                                                                                                 self.d_type,
-                                                                                                 item_type)),
-                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+        return PythonQuadConstraintStream(self.delegate.ifNotExists(item_type, extract_joiners(joiners, self.a_type,
+                                                                                                   self.b_type,
+                                                                                                   self.c_type,
+                                                                                                   self.d_type,
+                                                                                                   item_type)),
+                                              self.package, self.a_type, self.b_type, self.c_type, self.d_type)
 
-    def ifExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['PentaJoiner']) \
-            -> 'PythonQuadConstraintStream':
-        item_type = get_class(item_type)
-        return PythonQuadConstraintStream(self.delegate.ifExistsOtherIncludingNullVars(item_type,
-                                                                                       extract_joiners(joiners,
-                                                                                                       self.a_type,
-                                                                                                       self.b_type,
-                                                                                                       self.c_type,
-                                                                                                       self.d_type,
-                                                                                                       item_type)),
-                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+    ifNotExists = if_not_exists
 
-    def ifNotExists(self, item_type: Type, *joiners: List['PentaJoiner']) -> 'PythonQuadConstraintStream':
-        item_type = get_class(item_type)
-        return PythonQuadConstraintStream(self.delegate.ifNotExists(item_type, extract_joiners(joiners,
-                                                                                               self.a_type,
-                                                                                               self.b_type,
-                                                                                               self.c_type,
-                                                                                               self.d_type,
-                                                                                               item_type)),
-                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+    def if_not_exists_including_null_vars(self, item_type: Type[E_], *joiners: 'PentaJoiner[A, B, C, D, E_]') -> \
+            'PythonQuadConstraintStream[A,B,C,D]':
+        """Create a new QuadConstraintStream for every A, B, C, D where there does not exist an E where all specified
+        joiners are satisfied.
 
-    def ifNotExistsIncludingNullVars(self, item_type: Type, *joiners: List['PentaJoiner']) \
-            -> 'PythonQuadConstraintStream':
+        :param item_type:
+
+        :param joiners:
+
+        :return:
+        """
         item_type = get_class(item_type)
         return PythonQuadConstraintStream(self.delegate.ifNotExistsIncludingNullVars(item_type,
-                                                                                     extract_joiners(joiners,
-                                                                                                     self.a_type,
-                                                                                                     self.b_type,
-                                                                                                     self.c_type,
-                                                                                                     self.d_type,
-                                                                                                     item_type)),
-                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+                                                                                         extract_joiners(joiners,
+                                                                                                         self.a_type,
+                                                                                                         self.b_type,
+                                                                                                         self.c_type,
+                                                                                                         self.d_type,
+                                                                                                         item_type)),
+                                              self.package,
+                                              self.a_type,
+                                              self.b_type,
+                                              self.c_type,
+                                              self.d_type)
 
-    def ifNotExistsOther(self, item_type: Type, *joiners: List['PentaJoiner']) -> 'PythonQuadConstraintStream':
-        item_type = get_class(item_type)
-        return PythonQuadConstraintStream(self.delegate.ifNotExistsOther(item_type, extract_joiners(joiners,
-                                                                                                    self.a_type,
-                                                                                                    self.b_type,
-                                                                                                    self.c_type,
-                                                                                                    self.d_type,
-                                                                                                    item_type)),
-                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+    ifNotExistsIncludingNullVars = if_not_exists_including_null_vars
 
-    def ifNotExistsOtherIncludingNullVars(self, item_type: Type, *joiners: List['PentaJoiner']) \
-            -> 'PythonQuadConstraintStream':
-        item_type = get_class(item_type)
-        return PythonQuadConstraintStream(self.delegate.ifNotExistsOtherIncludingNullVars(item_type,
-                                                                                          extract_joiners(joiners,
-                                                                                                          self.a_type,
-                                                                                                          self.b_type,
-                                                                                                          self.c_type,
-                                                                                                          self.d_type,
-                                                                                                          item_type)),
-                                          self.package, self.a_type, self.b_type, self.c_type, self.d_type)
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B, C, D], A_]) -> 'PythonUniConstraintStream[A_]':
+        ...
 
-    def groupBy(self, *args):
+    @overload
+    def group_by(self, collector: 'QuadConstraintCollector[A, B, C, D, Any, A_]') -> 'PythonUniConstraintStream[A_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C, D], A_], second_key_mapping: Callable[[A, B, C, D], B_]) -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B, C, D], A_], collector: 'QuadConstraintCollector[A, B, C, D, Any, B_]') -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'QuadConstraintCollector[A, B, C, D, Any, A_]',
+                 second_collector: 'QuadConstraintCollector[A, B, C, D, Any, B_]') -> 'PythonBiConstraintStream[A_, B_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C, D], A_], second_key_mapping: Callable[[A, B, C, D], B_],
+                 third_key_mapping: Callable[[A, B, C, D], C_]) -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C, D], A_], second_key_mapping: Callable[[A, B, C, D], B_],
+                 collector: 'QuadConstraintCollector[A, B, C, D, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B, C, D], A_], first_collector: 'QuadConstraintCollector[A, B, C, D, Any, B_]',
+                 second_collector: 'QuadConstraintCollector[A, B, C, D, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'QuadConstraintCollector[A, B, C, D, Any, A_]',
+                 second_collector: 'QuadConstraintCollector[A, B, C, D, Any, B_]',
+                 third_collector: 'QuadConstraintCollector[A, B, C, D, Any, C_]') -> 'PythonTriConstraintStream[A_, B_, C_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C, D], A_], second_key_mapping: Callable[[A, B, C, D], B_],
+                 third_key_mapping: Callable[[A, B, C, D], C_], fourth_key_mapping: Callable[[A, B, C, D], D_]) -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C, D], A_], second_key_mapping: Callable[[A, B, C, D], B_],
+                 third_key_mapping: Callable[[A, B, C, D], C_], collector: 'QuadConstraintCollector[A, B, C, D, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_key_mapping: Callable[[A, B, C, D], A_], second_key_mapping: Callable[[A, B, C, D], B_],
+                 first_collector: 'QuadConstraintCollector[A, B, C, D, Any, C_]',
+                 second_collector: 'QuadConstraintCollector[A, B, C, D, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, key_mapping: Callable[[A, B, C, D], A_], first_collector: 'QuadConstraintCollector[A, B, C, D, Any, B_]',
+                 second_collector: 'QuadConstraintCollector[A, B, C, D, Any, C_]',
+                 third_collector: 'QuadConstraintCollector[A, B, C, D, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    @overload
+    def group_by(self, first_collector: 'QuadConstraintCollector[A, B, C, D, Any, A_]',
+                 second_collector: 'QuadConstraintCollector[A, B, C, D, Any, B_]',
+                 third_collector: 'QuadConstraintCollector[A, B, C, D, Any, C_]',
+                 fourth_collector: 'QuadConstraintCollector[A, B, C, D, Any, D_]') -> 'PythonQuadConstraintStream[A_, B_, C_, D_]':
+        ...
+
+    def group_by(self, *args):
+        """Collect items into groups using the group_key_function(s) and optionally aggregate the group's items into a
+        result.
+
+        The syntax of group_by is zero to four group_key functions, followed by zero to four collectors. At most
+        four arguments can be passed to group_by.
+
+        If no group_key function is passed to group_by, all items in the stream are aggregated into a single result
+        by the passed constraint collectors.
+
+        Examples:
+
+            - # count the items in this stream; returns Uni[int]
+
+              group_by(ConstraintCollectors.count_quad())
+
+            - # count the number of shifts each employee has; returns Bi[Employee]
+
+              group_by(lambda shift, _, _, _: shift.employee, ConstraintCollectors.count_quad())
+
+            - # count the number of shifts each employee has on a date; returns Tri[Employee, datetime.date, int]
+
+              group_by(lambda shift, _, _, _: shift.employee, lambda shift, _, _, _: shift.date,
+              ConstraintCollectors.count_quad())
+
+            - # count the number of shifts each employee has on a date; returns Tri[Employee, datetime.date, int]
+
+              group_by(lambda shift, _, _, _: shift.employee, lambda shift, _, _, _: shift.date,
+              ConstraintCollectors.count_quad())
+
+            - # get the dates of the first and last shift of each employee; returns Tri[Employee, datetime.date,
+              datetime.date]
+
+              group_by(lambda shift, _, _, _: shift.employee,
+              ConstraintCollectors.min(lambda shift, _, _, _: shift.date)
+              ConstraintCollectors.max(lambda shift, _, _, _: shift.date))
+
+        The type of stream returned depends on the number of arguments passed:
+
+        - 1 -> UniConstraintStream
+
+        - 2 -> BiConstraintStream
+
+        - 3 -> TriConstraintStream
+
+        - 4 -> QuadConstraintStream
+
+        :param args:
+
+        :return:
+        """
         return perform_group_by(self.delegate, self.package, args, self.a_type, self.b_type, self.c_type, self.d_type)
 
-    def map(self, mapping_function) -> 'PythonUniConstraintStream':
+    groupBy = group_by
+
+    def map(self, mapping_function: Callable[[A,B,C,D], A_]) -> 'PythonUniConstraintStream[A_]':
+        """Transforms the stream in such a way that tuples are remapped using the given function.
+        :param mapping_function:
+
+        :return:
+        """
         translated_function = function_cast(mapping_function)
         return PythonUniConstraintStream(self.delegate.map(translated_function), self.package,
-                                         JClass('java.lang.Object'))
+                                             JClass('java.lang.Object'))
 
-    def flattenLast(self, flattening_function) -> 'PythonQuadConstraintStream':
+    def flatten_last(self, flattening_function) -> 'PythonQuadConstraintStream[A,B,C,D]':
+        """Takes each tuple and applies a mapping on it, which turns the tuple into an Iterable.
+
+        :param flattening_function:
+
+        :return:
+        """
         def wrapped_function(last_item):
             from java.util import ArrayList
             items = flattening_function(last_item)
@@ -874,15 +2064,64 @@ class PythonQuadConstraintStream:
             for item in items:
                 out.add(item)
             return out
+
         translated_function = function_cast(wrapped_function)
         return PythonQuadConstraintStream(self.delegate.flattenLast(translated_function), self.package,
-                                          self.a_type, self.b_type, self.c_type, JClass('java.lang.Object'))
+                                              JClass('java.lang.Object'), JClass('java.lang.Object'),
+                                              JClass('java.lang.Object'), JClass('java.lang.Object'))
 
-    def distinct(self) -> 'PythonQuadConstraintStream':
-        return PythonQuadConstraintStream(self.delegate.distinct(), self.package, self.a_type,
-                                          self.b_type, self.c_type, self.d_type)
+    flattenLast = flatten_last
 
-    def penalize(self, *args):
+    def distinct(self) -> 'PythonQuadConstraintStream[A,B,C,D]':
+        """Transforms the stream in such a way that all the tuples going through it are distinct.
+
+        :return:
+        """
+        return PythonQuadConstraintStream(self.delegate.distinct(), self.package, self.a_type, self.b_type,
+                                              self.c_type, self.d_type)
+
+    @overload
+    def penalize(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A, B, C, D], int]) -> \
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def penalize(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+                 match_weigher: Callable[[A, B, C, D], int]) -> 'Constraint':
+        ...
+
+    def penalize(self, *args) -> 'Constraint':
+        """Negatively impact the Score: subtract the constraint_weight for each match (multiplied by an optional
+        match_weigher function).
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use penalize_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - penalize(constraint_name: str, constraint_weight: Score)
+
+            - penalize(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - penalize(constraint_name: str, constraint_weight: Score, match_weigher: (A, B, C, D) -> int)
+
+            - penalize(constraint_package: str, constraint_name: str, constraint_weight: Score,
+              match_weigher: (A, B, C, D) -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -891,22 +2130,63 @@ class PythonQuadConstraintStream:
             return self.delegate.penalize(constraint_info.constraint_package, constraint_info.constraint_name,
                                           constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def penalizeLong(self, *args):
-        raise NotImplementedError
+    def penalize_long(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeBigDecimal(self, *args):
-        raise NotImplementedError
+    def penalize_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurable(self, *args):
-        raise NotImplementedError
+    def penalize_configurable(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurableLong(self, *args):
-        raise NotImplementedError
+    def penalize_configurable_long(self, *args) -> 'Constraint':
+        ...
 
-    def penalizeConfigurableBigDecimal(self, *args):
-        raise NotImplementedError
+    def penalize_configurable_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def reward(self, *args):
+    @overload
+    def reward(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A, B, C, D], int]) -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def reward(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+               match_weigher: Callable[[A, B, C, D], int]) -> 'Constraint':
+        ...
+
+    def reward(self, *args) -> 'Constraint':
+        """Positively impact the Score: add the constraint_weight for each match (multiplied by an optional
+        match_weigher function).
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use reward_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - reward(constraint_name: str, constraint_weight: Score)
+
+            - reward(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - reward(constraint_name: str, constraint_weight: Score, match_weigher: (A, B, C, D) -> int)
+
+            - reward(constraint_package: str, constraint_name: str, constraint_weight: Score,
+              match_weigher: (A, B, C, D) -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -915,16 +2195,59 @@ class PythonQuadConstraintStream:
             return self.delegate.reward(constraint_info.constraint_package, constraint_info.constraint_name,
                                         constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def rewardLong(self, *args):
-        raise NotImplementedError
+    def reward_long(self, *args) -> 'Constraint':
+        ...
 
-    def rewardBigDecimal(self, *args):
-        raise NotImplementedError
+    def reward_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def rewardConfigurable(self, *args):
-        raise NotImplementedError
+    def reward_configurable(self, *args) -> 'Constraint':
+        ...
 
-    def impact(self, *args):
+    @overload
+    def impact(self, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_name: str, constraint_weight: 'Score', match_weigher: Callable[[A, B, C], int]) -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score') -> \
+            'Constraint':
+        ...
+
+    @overload
+    def impact(self, constraint_package: str, constraint_name: str, constraint_weight: 'Score',
+               match_weigher: Callable[[A, B, C, D], int]) -> 'Constraint':
+        ...
+
+    def impact(self, *args) -> 'Constraint':
+        """Positively or negatively impact the Score: add the constraint_weight for each match
+        (multiplied by an optional match_weigher function).
+
+        Use penalize(...) or reward(...) instead, unless this constraint can both have positive and negative weights.
+
+        To avoid hard-coding the constraint_weight, to allow end-users to tweak it,
+        use impact_configurable and a ConstraintConfiguration instead.
+
+        There are four overloads available for this method:
+
+            - impact(constraint_name: str, constraint_weight: Score)
+
+            - impact(constraint_package: str, constraint_name: str, constraint_weight: Score)
+
+            - impact(constraint_name: str, constraint_weight: Score, match_weigher: (A, B, C, D) -> int)
+
+            - impact(constraint_package: str, constraint_name: str, constraint_weight: Score,
+              match_weigher: (A, B, C, D) -> int)
+
+        The Constraint.getConstraintPackage() defaults to the package of the PlanningSolution class.
+
+        :return:
+        """
         constraint_info = extract_constraint_info(self.package, args)
         if constraint_info.impact_function is None:
             return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
@@ -933,11 +2256,11 @@ class PythonQuadConstraintStream:
             return self.delegate.impact(constraint_info.constraint_package, constraint_info.constraint_name,
                                         constraint_info.score, to_int_function_cast(constraint_info.impact_function))
 
-    def impactLong(self, *args):
-        raise NotImplementedError
+    def impact_long(self, *args) -> 'Constraint':
+        ...
 
-    def impactBigDecimal(self, *args):
-        raise NotImplementedError
+    def impact_big_decimal(self, *args) -> 'Constraint':
+        ...
 
-    def impactConfigurable(self, *args):
-        raise NotImplementedError
+    def impact_configurable(self, *args) -> 'Constraint':
+        ...

--- a/optapy-core/tests/test_anchors.py
+++ b/optapy-core/tests/test_anchors.py
@@ -69,10 +69,10 @@ class ChainedSolution:
 
 
 @optapy.constraint_provider
-def chained_constraints(constraint_factory):
+def chained_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
     return [
-        constraint_factory.forEach(ChainedEntity)
-                          .groupBy(lambda entity: entity.anchor, optapy.constraint.ConstraintCollectors.count())
+        constraint_factory.for_each(ChainedEntity)
+                          .group_by(lambda entity: entity.anchor, optapy.constraint.ConstraintCollectors.count())
                           .reward('Maximize chain length', optapy.score.SimpleScore.ONE,
                                   lambda anchor, count: count * count)
     ]

--- a/optapy-core/tests/test_collectors.py
+++ b/optapy-core/tests/test_collectors.py
@@ -65,8 +65,8 @@ def test_min():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-                .groupBy(optapy.constraint.ConstraintCollectors.min(lambda entity: entity.value.number))
+            constraint_factory.for_each(Entity)
+                .group_by(optapy.constraint.ConstraintCollectors.min(lambda entity: entity.value.number))
                 .reward('Min value', optapy.score.SimpleScore.ONE, lambda min_value: min_value)
         ]
 
@@ -97,8 +97,8 @@ def test_max():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-            .groupBy(optapy.constraint.ConstraintCollectors.max(lambda entity: entity.value.number))
+            constraint_factory.for_each(Entity)
+            .group_by(optapy.constraint.ConstraintCollectors.max(lambda entity: entity.value.number))
             .reward('Max value', optapy.score.SimpleScore.ONE, lambda max_value: max_value)
         ]
 
@@ -129,8 +129,8 @@ def test_sum():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-            .groupBy(optapy.constraint.ConstraintCollectors.sum(lambda entity: entity.value.number))
+            constraint_factory.for_each(Entity)
+            .group_by(optapy.constraint.ConstraintCollectors.sum(lambda entity: entity.value.number))
             .reward('Sum value', optapy.score.SimpleScore.ONE, lambda sum_value: sum_value)
         ]
 
@@ -161,8 +161,8 @@ def test_average():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-            .groupBy(optapy.constraint.ConstraintCollectors.average(lambda entity: entity.value.number))
+            constraint_factory.for_each(Entity)
+            .group_by(optapy.constraint.ConstraintCollectors.average(lambda entity: entity.value.number))
             .reward('Average value', optapy.score.SimpleScore.ONE, lambda average_value: int(10 * average_value))
         ]
 
@@ -193,9 +193,9 @@ def test_count():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
+            constraint_factory.for_each(Entity)
                 .filter(lambda entity: entity.code[0] == 'A')
-                .groupBy(optapy.constraint.ConstraintCollectors.count())
+                .group_by(optapy.constraint.ConstraintCollectors.count())
                 .reward('Count value', optapy.score.SimpleScore.ONE, lambda count: count)
         ]
 
@@ -220,8 +220,8 @@ def test_count_distinct():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-            .groupBy(optapy.constraint.ConstraintCollectors.countDistinct(lambda entity: entity.value))
+            constraint_factory.for_each(Entity)
+            .group_by(optapy.constraint.ConstraintCollectors.count_distinct(lambda entity: entity.value))
             .reward('Count distinct value', optapy.score.SimpleScore.ONE, lambda count: count)
         ]
 
@@ -252,8 +252,8 @@ def test_to_list():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-            .groupBy(optapy.constraint.ConstraintCollectors.toList(lambda entity: entity.value))
+            constraint_factory.for_each(Entity)
+            .group_by(optapy.constraint.ConstraintCollectors.to_list(lambda entity: entity.value))
             .reward('list size', optapy.score.SimpleScore.ONE, lambda values: len(values))
         ]
 
@@ -284,8 +284,8 @@ def test_to_set():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-            .groupBy(optapy.constraint.ConstraintCollectors.toSet(lambda entity: entity.value))
+            constraint_factory.for_each(Entity)
+            .group_by(optapy.constraint.ConstraintCollectors.to_set(lambda entity: entity.value))
             .reward('set size', optapy.score.SimpleScore.ONE, lambda values: len(values))
         ]
 
@@ -316,8 +316,8 @@ def test_to_map():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-            .groupBy(optapy.constraint.ConstraintCollectors.toMap(lambda entity: entity.code, lambda entity: entity.value.number))
+            constraint_factory.for_each(Entity)
+            .group_by(optapy.constraint.ConstraintCollectors.to_map(lambda entity: entity.code, lambda entity: entity.value.number))
             .filter(lambda entity_map: next(iter(entity_map['A'])) == 1)
             .reward('map at B', optapy.score.SimpleScore.ONE, lambda entity_map: next(iter(entity_map['B'])))
         ]
@@ -349,8 +349,8 @@ def test_to_sorted_set():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-            .groupBy(optapy.constraint.ConstraintCollectors.toSortedSet(lambda entity: entity.value.number))
+            constraint_factory.for_each(Entity)
+            .group_by(optapy.constraint.ConstraintCollectors.to_sorted_set(lambda entity: entity.value.number))
             .reward('min', optapy.score.SimpleScore.ONE, lambda values: next(iter(values)))
         ]
 
@@ -381,8 +381,8 @@ def test_to_sorted_map():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-            .groupBy(optapy.constraint.ConstraintCollectors.toMap(lambda entity: entity.code, lambda entity: entity.value.number))
+            constraint_factory.for_each(Entity)
+            .group_by(optapy.constraint.ConstraintCollectors.to_sorted_map(lambda entity: entity.code, lambda entity: entity.value.number))
             .filter(lambda entity_map: next(iter(entity_map['B'])) == 1)
             .reward('map at A', optapy.score.SimpleScore.ONE, lambda entity_map: next(iter(entity_map['A'])))
         ]
@@ -418,8 +418,8 @@ def test_conditionally():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-            .groupBy(optapy.constraint.ConstraintCollectors.conditionally(lambda entity: entity.code[0] == 'A',
+            constraint_factory.for_each(Entity)
+            .group_by(optapy.constraint.ConstraintCollectors.conditionally(lambda entity: entity.code[0] == 'A',
                                                                           optapy.constraint.ConstraintCollectors.count()))
             .reward('Conditionally count value', optapy.score.SimpleScore.ONE, lambda count: count)
         ]
@@ -445,8 +445,8 @@ def test_compose():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
-            .groupBy(optapy.constraint.ConstraintCollectors.compose(
+            constraint_factory.for_each(Entity)
+            .group_by(optapy.constraint.ConstraintCollectors.compose(
                 optapy.constraint.ConstraintCollectors.min(lambda entity: entity.value.number),
                 optapy.constraint.ConstraintCollectors.max(lambda entity: entity.value.number),
                 lambda a,b: (a,b)
@@ -482,9 +482,9 @@ def test_flatten_last():
     @optapy.constraint_provider
     def define_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
+            constraint_factory.for_each(Entity)
             .map(lambda entity: (1, 2, 3))
-            .flattenLast(lambda the_tuple: the_tuple)
+            .flatten_last(lambda the_tuple: the_tuple)
             .reward('Count', optapy.score.SimpleScore.ONE)
         ]
 

--- a/optapy-core/tests/test_custom_shadow_variables.py
+++ b/optapy-core/tests/test_custom_shadow_variables.py
@@ -58,7 +58,7 @@ def test_custom_shadow_variable():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(MyPlanningEntity)
+            constraint_factory.for_each(MyPlanningEntity)
                 .filter(lambda entity: entity.value * 2 == entity.value_squared)
                 .reward('Double value is value squared', optapy.score.SimpleScore.ONE)
         ]

--- a/optapy-core/tests/test_domain.py
+++ b/optapy-core/tests/test_domain.py
@@ -27,7 +27,7 @@ def test_single_property():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
+            constraint_factory.for_each(Entity)
                               .join(Value,
                                     optapy.constraint.Joiners.equal(lambda entity: entity.value,
                                                                     lambda value: value.code))
@@ -98,11 +98,11 @@ def test_tuple_group_by_key():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
+            constraint_factory.for_each(Entity)
                 .join(Value,
                       optapy.constraint.Joiners.equal(lambda entity: entity.value,
                                                       lambda value: value.code))
-                .groupBy(lambda entity, value: (0, value), optapy.constraint.ConstraintCollectors.countBi())
+                .group_by(lambda entity, value: (0, value), optapy.constraint.ConstraintCollectors.count_bi())
                 .reward('Same as value', optapy.score.SimpleScore.ONE, lambda _, count: count),
         ]
 
@@ -190,19 +190,19 @@ def test_python_object():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
+            constraint_factory.for_each(Entity)
                 .join(Value,
-                      optapy.constraint.Joiners.lessThanOrEqual(lambda entity: entity.value,
-                                                                lambda value: value.code))
+                      optapy.constraint.Joiners.less_than_or_equal(lambda entity: entity.value,
+                                                                   lambda value: value.code))
                 .reward('Same as value', optapy.score.SimpleScore.ONE),
-            constraint_factory.forEach(Entity)
-                .groupBy(lambda entity: entity.value, optapy.constraint.ConstraintCollectors.count())
+            constraint_factory.for_each(Entity)
+                .group_by(lambda entity: entity.value, optapy.constraint.ConstraintCollectors.count())
                 .reward('Entity have same value', optapy.score.SimpleScore.ONE, lambda value, count: count * count),
-            constraint_factory.forEach(optapy.get_class(Entity))
-                .groupBy(lambda entity: (entity.code, entity.value))
+            constraint_factory.for_each(Entity)
+                .group_by(lambda entity: (entity.code, entity.value))
                 .join(Entity,
-                    optapy.constraint.Joiners.equal(lambda pair: pair[0], lambda entity: entity.code),
-                    optapy.constraint.Joiners.equal(lambda pair: pair[1], lambda entity: entity.value))
+                      optapy.constraint.Joiners.equal(lambda pair: pair[0], lambda entity: entity.code),
+                      optapy.constraint.Joiners.equal(lambda pair: pair[1], lambda entity: entity.value))
                 .reward('Entity for pair', optapy.score.SimpleScore.ONE),
         ]
 
@@ -273,7 +273,7 @@ def test_list_variable():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(optapy.get_class(Entity))
+            constraint_factory.for_each(Entity)
                 .filter(lambda entity: any(entity.value[index] != index + 1 for index in range(len(entity.value))))
                 .penalize('Value is not the same as index', optapy.score.SimpleScore.ONE, count_mismatches),
         ]

--- a/optapy-core/tests/test_inverse_relation.py
+++ b/optapy-core/tests/test_inverse_relation.py
@@ -57,9 +57,9 @@ class InverseRelationSolution:
 
 
 @optapy.constraint_provider
-def inverse_relation_constraints(constraint_factory):
+def inverse_relation_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
     return [
-        constraint_factory.forEach(InverseRelationValue)
+        constraint_factory.for_each(InverseRelationValue)
                           .filter(lambda value: len(value.entities) > 1)
                           .penalize('Only one entity per value', optapy.score.SimpleScore.ONE)
     ]

--- a/optapy-core/tests/test_pinning.py
+++ b/optapy-core/tests/test_pinning.py
@@ -116,7 +116,7 @@ def test_planning_pin():
     @optapy.constraint_provider
     def my_constraints(constraint_factory):
         return [
-            constraint_factory.forEach(Point)
+            constraint_factory.for_each(Point)
                 .penalize("Minimize Value", optapy.score.SimpleScore.ONE, lambda point: point.value)
         ]
 

--- a/optapy-core/tests/test_score_manager.py
+++ b/optapy-core/tests/test_score_manager.py
@@ -25,7 +25,7 @@ class Entity:
 @optapy.constraint_provider
 def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
     return [
-        constraint_factory.forEach(Entity)
+        constraint_factory.for_each(Entity)
             .reward('Maximize Value', optapy.score.SimpleScore.ONE, lambda entity: entity.value),
     ]
 

--- a/optapy-core/tests/test_solver_config.py
+++ b/optapy-core/tests/test_solver_config.py
@@ -30,7 +30,7 @@ class Value:
 @optapy.constraint_provider
 def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
     return [
-        constraint_factory.forEach(Entity)
+        constraint_factory.for_each(Entity)
             .join(Value,
                   optapy.constraint.Joiners.equal(lambda entity: entity.value,
                                                   lambda value: value.code))

--- a/optapy-core/tests/test_solver_events.py
+++ b/optapy-core/tests/test_solver_events.py
@@ -21,7 +21,7 @@ def test_solver_events():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
+            constraint_factory.for_each(Entity)
                 .reward('Maximize value', optapy.score.SimpleScore.ONE, lambda entity: entity.value),
         ]
 

--- a/optapy-core/tests/test_solver_manager.py
+++ b/optapy-core/tests/test_solver_manager.py
@@ -57,13 +57,13 @@ def test_solve():
     @optapy.constraint_provider
     def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
         return [
-            constraint_factory.forEach(Entity)
+            constraint_factory.for_each(Entity)
                 .filter(get_lock)
                 .reward('Wait for lock', optapy.score.SimpleScore.ONE),
-            constraint_factory.forEach(Entity)
+            constraint_factory.for_each(Entity)
                 .reward('Maximize Value', optapy.score.SimpleScore.ONE, lambda entity: entity.value.value),
-            constraint_factory.forEachUniquePair(Entity,
-                                                 optapy.constraint.Joiners.equal(lambda entity: entity.value.value))
+            constraint_factory.for_each_unique_pair(Entity,
+                                                    optapy.constraint.Joiners.equal(lambda entity: entity.value.value))
                 .penalize('Same Value', optapy.score.SimpleScore.of(12)),
         ]
 


### PR DESCRIPTION
Unlike Java, all Python overloads shares the same docstring
(the docstring of the implementon). The Javadoc of overloaded
methods (in particular group_by, penalize, reward, impact)
has been combined so that the docs will render correctly
in Python IDE's.