### PR TITLE
fix: Allow Constraint Streams to be used as parameters to join

### DIFF
--- a/optapy-core/src/main/python/constraint_stream.py
+++ b/optapy-core/src/main/python/constraint_stream.py
@@ -327,6 +327,7 @@ class PythonUniConstraintStream(Generic[A]):
         b_type = None
         if isinstance(unistream_or_type, PythonUniConstraintStream):
             b_type = unistream_or_type.a_type
+            unistream_or_type = unistream_or_type.delegate
         else:
             b_type = get_class(unistream_or_type)
             unistream_or_type = b_type
@@ -907,6 +908,7 @@ class PythonBiConstraintStream(Generic[A, B]):
         c_type = None
         if isinstance(unistream_or_type, PythonUniConstraintStream):
             c_type = unistream_or_type.a_type
+            unistream_or_type = unistream_or_type.delegate
         else:
             c_type = get_class(unistream_or_type)
             unistream_or_type = c_type
@@ -1435,6 +1437,7 @@ class PythonTriConstraintStream(Generic[A, B, C]):
         d_type = None
         if isinstance(unistream_or_type, PythonUniConstraintStream):
             d_type = unistream_or_type.a_type
+            unistream_or_type = unistream_or_type.delegate
         else:
             d_type = get_class(unistream_or_type)
             unistream_or_type = d_type


### PR DESCRIPTION
The Python Constraint Streams wrappers passed themselves instead
of their delegate to join, which raise a TypeError since they
do not implement ConstraintStreams. To fix, the delegate is passed
instead.