### PR TITLE
Fix search index

### DIFF
--- a/optapy-docs/supplemental-ui/js/search-ui.js
+++ b/optapy-docs/supplemental-ui/js/search-ui.js
@@ -253,4 +253,7 @@
   enableSearchInput(false)
 
   globalScope.initSearch = initSearch
+  globalScope.antoraSearch = {
+    initSearch: initSearch
+  }
 })(typeof globalThis !== 'undefined' ? globalThis : window)


### PR DESCRIPTION
It appears antora-lunr changed it supplement file to use
antoraSearch.initSearch instead of initSearch, which in turns
broke the search function of our docs (since the GitHub action
did an automatic update).