### PR TITLE
Support arbitary PythonComparable as @planning_id

### DIFF
--- a/optapy-core/src/main/python/optaplanner_java_interop.py
+++ b/optapy-core/src/main/python/optaplanner_java_interop.py
@@ -60,6 +60,7 @@ def _get_python_object_attribute(object_id, name):
     import java.lang.Object
     import java.util.Collection
     import org.optaplanner.core.api.score.Score
+    from org.optaplanner.optapy import PythonComparable
     the_object = object_id
     python_object_getter = getattr(the_object, str(name))
     if not callable(python_object_getter):
@@ -75,8 +76,12 @@ def _get_python_object_attribute(object_id, name):
                                         org.optaplanner.core.api.score.Score)):
             out = JObject(python_object, java.lang.Object)
             return out
+        elif hasattr(python_object_getter, '__optaplannerPlanningId'):
+            return PythonComparable(
+                JProxy(org.optaplanner.optapy.OpaquePythonReference, inst=python_object, convert=True))
         else:
             return JProxy(org.optaplanner.optapy.OpaquePythonReference, inst=python_object, convert=True)
+
     except Exception as e:
         from org.optaplanner.optapy import OptaPyException  # noqa
         error = f'An exception occur when calling {str(name)} on {str(the_object)}: {str(e)}. Check the code.'

--- a/optapy-core/tests/test_domain.py
+++ b/optapy-core/tests/test_domain.py
@@ -340,6 +340,99 @@ def test_python_object():
     assert solution.entity.value == date1
 
 
+def test_custom_planning_id():
+    from uuid import uuid4
+    id_1 = uuid4()
+    id_2 = uuid4()
+    id_3 = uuid4()
+
+    @optapy.problem_fact
+    class Value:
+        def __init__(self, code):
+            self.code = code
+
+    @optapy.planning_entity
+    class Entity:
+        def __init__(self, code, value=None):
+            self.code = code
+            self.value = value
+
+        @optapy.planning_id
+        def get_code(self):
+            return self.code
+
+        @optapy.planning_variable(Value, value_range_provider_refs=['value_range'])
+        def get_value(self):
+            return self.value
+
+        def set_value(self, value):
+            self.value = value
+
+    @optapy.constraint_provider
+    def my_constraints(constraint_factory: optapy.constraint.ConstraintFactory):
+        return [
+            constraint_factory.for_each_unique_pair(Entity,
+                                                    optapy.constraint.Joiners.equal(lambda entity: entity.value))
+                .penalize('Same value', optapy.score.SimpleScore.ONE),
+        ]
+
+    @optapy.planning_solution
+    class Solution:
+        def __init__(self, entities, values, score=None):
+            self.entities = entities
+            self.values = values
+            self.score = score
+
+        @optapy.planning_entity_collection_property(Entity)
+        def get_entities(self):
+            return self.entities
+
+        @optapy.problem_fact_collection_property(Value)
+        @optapy.value_range_provider(range_id='value_range')
+        def get_values(self):
+            return self.values
+
+        @optapy.planning_score(optapy.score.SimpleScore)
+        def get_score(self) -> optapy.score.SimpleScore:
+            return self.score
+
+        def set_score(self, score):
+            self.score = score
+
+    solver_config = optapy.config.solver.SolverConfig()
+    termination_config = optapy.config.solver.termination.TerminationConfig()
+    termination_config.setBestScoreLimit('0')
+    solver_config.withSolutionClass(optapy.get_class(Solution)) \
+        .withEntityClasses(Entity) \
+        .withConstraintProviderClass(my_constraints) \
+        .withTerminationConfig(termination_config)
+
+    entity_1 = Entity(id_1)
+    entity_2 = Entity(id_2)
+    entity_3 = Entity(id_3)
+
+    value_1 = Value('A')
+    value_2 = Value('B')
+    value_3 = Value('C')
+    problem: Solution = Solution([
+        entity_1,
+        entity_2,
+        entity_3
+    ], [
+        value_1,
+        value_2,
+        value_3
+    ])
+    solver = optapy.solver_factory_create(solver_config).buildSolver()
+    solution = solver.solve(problem)
+    assert solution.get_score().getScore() == 0
+
+    encountered = set()
+    for entity in solution.entities:
+        assert entity.value not in encountered
+        encountered.add(entity.value)
+
+
 def test_list_variable():
     @optapy.planning_entity
     class Entity:


### PR DESCRIPTION
Due to OptaPlanner sanity checking @PlanningId, the field/method
must return a Comparable object. Thus, for methods annotated
with @planning_id, their corresponding field is of type
Comparable. This does not pose an issue for int and str,
which have correspond Java objects. It does pose an issue
for custom Python objects, like uuid, since you cannot
assign an OpaquePythonReference to Comparable. To fix this,
when getting attributes during cloning, _get_python_object_attribute
will return a PythonComparable if the attribute getter was annotated
with `@planning_id`, and otherwise return an OpaquePythonReference.