### PR TITLE
Support ValueRange, CountableValueRange and entity @value_range_provider

### DIFF
--- a/optapy-docs/src/modules/ROOT/pages/planner-configuration/planner-configuration.adoc
+++ b/optapy-docs/src/modules/ROOT/pages/planner-configuration/planner-configuration.adoc
@@ -613,11 +613,11 @@ For example, if a teacher can *never* teach in a room that does not belong to hi
 
 [source,python,options="nowrap"]
 ----
-    @planning_variable(value_range_provider_refs = ["department_room_range"])
+    @planning_variable(Room, value_range_provider_refs = ["department_room_range"])
     def get_room(self):
         return self.room
 
-    @value_range_provider(range_id = "department_room_range")
+    @value_range_provider(range_id = "department_room_range", value_range_type = Room)
     def get_possible_room_list(self):
         return self.course.teacher.department.room_list
 ----


### PR DESCRIPTION
There was a bug with @value_range_provider where it would only work without @problem_fact_collection_property/@planning_entity_collection_property if it was for a OpaquePythonReference type due to its generated function signature.

Now the generated function signature is:
- Type, if ValueRange is assignable from Type
- List<Type>, if Type has a corresponding Java class
- OpaquePythonReference[] otherwise

A ValueRange cannot be directly assigned to the value range's field in the PlanningEntity class because it is proxied by JPype. So we create a NEW Proxy (one that implements ValueRange/CountableValueRange), that reuses its InvocationHandler, which is used instead (and can be cast to ValueRange as a result).