### PR TITLE
Fix issues in Sonarcloud action

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        java-version: [ 11 ]
+        java-version: [ 17 ]  # JaCoCo segfaults Java 11 JVM but not Java 17 JVM when Python tests finish
         maven-version: [ '3.8.6' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -47,12 +47,16 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
+          cache-dependency-path: |
+            **/setup.py
 
       - name: Python 3.10 Setup
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip'
+          cache-dependency-path: |
+            **/setup.py
 
       - name: Install tox
         run:


### PR DESCRIPTION
- setup-python fails if it cannot find a requirements.txt file if cache-dependency-path is not set
- For some reason, Java 11 JVM crash with Python JaCoCo execution, but Java 17 JVM does not