### PR TITLE
Copy values view before iterating the value view in ConstraintVerifier.given

### DIFF
--- a/optapy-core/src/main/python/test/__init__.py
+++ b/optapy-core/src/main/python/test/__init__.py
@@ -88,7 +88,8 @@ class SingleConstraintVerification(Generic[Solution_]):
             wrapped_fact = PythonSolver.wrapFact(fact_class, fact, reference_map)
             wrapped_facts.append(wrapped_fact)
 
-        for fact in reference_map.values():
+        referenced_facts = list(reference_map.values())
+        for fact in referenced_facts:
             if isinstance(fact, CPythonBackedPythonLikeObject):
                 CPythonBackedPythonInterpreter.updateJavaObjectFromPythonObject(fact, JProxy(OpaquePythonReference,
                                                                                 inst=getattr(fact, '$cpythonReference'),
@@ -129,7 +130,8 @@ class MultiConstraintVerification(Generic[Solution_]):
             wrapped_fact = PythonSolver.wrapFact(fact_class, fact, reference_map)
             wrapped_facts.append(wrapped_fact)
 
-        for fact in reference_map.values():
+        referenced_facts = list(reference_map.values())
+        for fact in referenced_facts:
             if isinstance(fact, CPythonBackedPythonLikeObject):
                 CPythonBackedPythonInterpreter.updateJavaObjectFromPythonObject(fact, JProxy(OpaquePythonReference,
                                                                                 inst=getattr(fact, '$cpythonReference'),


### PR DESCRIPTION
After fixing MirrorWithExtrasMap.values() method
so it conforms to the Map API (the Collection
MUST reflect changes to the Map and vice versa),
converting facts in ConstraintVerifier raise
a ConcurrentExecutionException since it iterating
through the changing map.

To prevent the ConcurrentExecutionException, we
copy values to it own list, and iterate through
that list instead.