### PR TITLE
Bump optapy version to 8.30.0b0

### DIFF
--- a/jpyinterpreter/pom.xml
+++ b/jpyinterpreter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optapy-parent</artifactId>
-    <version>8.28.0.Final</version>
+    <version>8.30.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jpyinterpreter</artifactId>

--- a/jpyinterpreter/setup.py
+++ b/jpyinterpreter/setup.py
@@ -82,12 +82,12 @@ this_directory = Path(__file__).parent
 
 setup(
     name='jpyinterpreter',
-    version='8.28.0b0',
+    version='8.30.0b0',
     license='Apache License Version 2.0',
     license_file='LICENSE',
     description='A Python bytecode to Java bytecode translator',
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Java Libraries',
         'License :: OSI Approved :: Apache Software License',

--- a/optapy-core/pom.xml
+++ b/optapy-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optapy-parent</artifactId>
-    <version>8.28.0.Final</version>
+    <version>8.30.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>optapy</artifactId>

--- a/optapy-docs/pom.xml
+++ b/optapy-docs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optapy-parent</artifactId>
-    <version>8.28.0.Final</version>
+    <version>8.30.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -29,7 +29,7 @@
     -->
     <source.document.name>.index.adoc</source.document.name>
 
-    <version.optapy>8.28.0b0</version.optapy>
+    <version.optapy>8.30.0b0</version.optapy>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.optaplanner</groupId>
     <artifactId>optaplanner-build-parent</artifactId>
-    <version>8.28.0.Final</version>
+    <version>8.30.0.Final</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='optapy',
-    version='8.28.0b0',
+    version='8.30.0b0',
     license='Apache License Version 2.0',
     license_file='LICENSE',
     description='An AI constraint solver that optimizes planning and scheduling problems',
@@ -112,7 +112,7 @@ setup(
         'OptaPlanner Homepage': 'https://www.optaplanner.org/',
     },
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Software Development :: Libraries :: Java Libraries',


### PR DESCRIPTION
Forgot to update development status
tag from alpha to beta in previous release,
so doing it here.