### PR TITLE
Optimize calls

### DIFF
--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/FieldDescriptor.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/FieldDescriptor.java
@@ -7,21 +7,21 @@ import org.optaplanner.jpyinterpreter.types.PythonLikeType;
 public class FieldDescriptor {
 
     final String pythonFieldName;
-
     final String javaFieldName;
-
     final String declaringClassInternalName;
     final String javaFieldTypeDescriptor;
     final PythonLikeType fieldPythonLikeType;
+    final boolean isTrueFieldDescriptor;
 
     public FieldDescriptor(String pythonFieldName, String javaFieldName,
             String declaringClassInternalName, String javaFieldTypeDescriptor,
-            PythonLikeType fieldPythonLikeType) {
+            PythonLikeType fieldPythonLikeType, boolean isTrueFieldDescriptor) {
         this.pythonFieldName = pythonFieldName;
         this.javaFieldName = javaFieldName;
         this.declaringClassInternalName = declaringClassInternalName;
         this.javaFieldTypeDescriptor = javaFieldTypeDescriptor;
         this.fieldPythonLikeType = fieldPythonLikeType;
+        this.isTrueFieldDescriptor = isTrueFieldDescriptor;
     }
 
     public String getPythonFieldName() {
@@ -44,6 +44,10 @@ public class FieldDescriptor {
         return fieldPythonLikeType;
     }
 
+    public boolean isTrueFieldDescriptor() {
+        return isTrueFieldDescriptor;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -56,13 +60,14 @@ public class FieldDescriptor {
         return pythonFieldName.equals(that.pythonFieldName) && javaFieldName.equals(that.javaFieldName)
                 && declaringClassInternalName.equals(that.declaringClassInternalName)
                 && javaFieldTypeDescriptor.equals(that.javaFieldTypeDescriptor)
-                && fieldPythonLikeType.equals(that.fieldPythonLikeType);
+                && fieldPythonLikeType.equals(that.fieldPythonLikeType)
+                && isTrueFieldDescriptor == that.isTrueFieldDescriptor;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(pythonFieldName, javaFieldName, declaringClassInternalName, javaFieldTypeDescriptor,
-                fieldPythonLikeType);
+                fieldPythonLikeType, isTrueFieldDescriptor);
     }
 
     @Override
@@ -73,6 +78,7 @@ public class FieldDescriptor {
                 ", declaringClassInternalName='" + declaringClassInternalName + '\'' +
                 ", javaFieldTypeDescriptor='" + javaFieldTypeDescriptor + '\'' +
                 ", fieldPythonLikeType=" + fieldPythonLikeType +
+                ", isTrueFieldDescriptor=" + isTrueFieldDescriptor +
                 '}';
     }
 }

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/LocalVariableHelper.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/LocalVariableHelper.java
@@ -219,6 +219,7 @@ public class LocalVariableHelper {
 
     public void readCallKeywords(MethodVisitor methodVisitor) {
         methodVisitor.visitVarInsn(Opcodes.ALOAD, getCallKeywordsSlot());
+        methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(PythonLikeTuple.class));
     }
 
     public void writeCallKeywords(MethodVisitor methodVisitor) {

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/MethodDescriptor.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/MethodDescriptor.java
@@ -16,11 +16,11 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 public class MethodDescriptor {
-    final String declaringClassInternalName;
-    final String methodName;
-    final String methodDescriptor;
+    private final String declaringClassInternalName;
+    private final String methodName;
+    private final String methodDescriptor;
 
-    final MethodType methodType;
+    private final MethodType methodType;
 
     private static Type resolveGenericType(java.lang.reflect.Type type, TypeVariable[] interfaceTypeVariables,
             List<Class<?>> typeArgumentList) {
@@ -156,13 +156,14 @@ public class MethodDescriptor {
     }
 
     public void callMethod(MethodVisitor methodVisitor) {
-        methodVisitor.visitMethodInsn(methodType.getOpcode(), declaringClassInternalName, methodName, methodDescriptor,
-                methodType == MethodType.INTERFACE);
+        methodVisitor.visitMethodInsn(getMethodType().getOpcode(), getDeclaringClassInternalName(), getMethodName(),
+                getMethodDescriptor(),
+                getMethodType() == MethodType.INTERFACE);
     }
 
     public MethodDescriptor withReturnType(Type returnType) {
-        return new MethodDescriptor(declaringClassInternalName, methodType, methodName,
-                Type.getMethodDescriptor(returnType, Type.getArgumentTypes(methodDescriptor)));
+        return new MethodDescriptor(getDeclaringClassInternalName(), getMethodType(), getMethodName(),
+                Type.getMethodDescriptor(returnType, Type.getArgumentTypes(getMethodDescriptor())));
     }
 
     @Override
@@ -174,21 +175,22 @@ public class MethodDescriptor {
             return false;
         }
         MethodDescriptor that = (MethodDescriptor) o;
-        return declaringClassInternalName.equals(that.declaringClassInternalName) && methodName.equals(that.methodName)
-                && methodDescriptor.equals(that.methodDescriptor);
+        return getDeclaringClassInternalName().equals(that.getDeclaringClassInternalName())
+                && getMethodName().equals(that.getMethodName())
+                && getMethodDescriptor().equals(that.getMethodDescriptor());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(declaringClassInternalName, methodName, methodDescriptor);
+        return Objects.hash(getDeclaringClassInternalName(), getMethodName(), getMethodDescriptor());
     }
 
     public Type getReturnType() {
-        return Type.getReturnType(methodDescriptor);
+        return Type.getReturnType(getMethodDescriptor());
     }
 
     public Type[] getParameterTypes() {
-        return Type.getArgumentTypes(methodDescriptor);
+        return Type.getArgumentTypes(getMethodDescriptor());
     }
 
     public enum MethodType {

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonBytecodeToJavaBytecodeTranslator.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonBytecodeToJavaBytecodeTranslator.java
@@ -234,17 +234,17 @@ public class PythonBytecodeToJavaBytecodeTranslator {
         String internalClassName = className.replace('.', '/');
         ClassWriter classWriter = new JavaPythonClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
         classWriter.visit(Opcodes.V11, Modifier.PUBLIC, internalClassName, null, Type.getInternalName(Object.class),
-                new String[] { methodDescriptor.declaringClassInternalName });
+                new String[] { methodDescriptor.getDeclaringClassInternalName() });
 
         final boolean isPythonLikeFunction =
-                methodDescriptor.declaringClassInternalName.equals(Type.getInternalName(PythonLikeFunction.class));
+                methodDescriptor.getDeclaringClassInternalName().equals(Type.getInternalName(PythonLikeFunction.class));
 
         createFields(classWriter);
         createConstructor(classWriter, internalClassName);
 
         MethodVisitor methodVisitor = classWriter.visitMethod(Modifier.PUBLIC,
-                methodDescriptor.methodName,
-                methodDescriptor.methodDescriptor,
+                methodDescriptor.getMethodName(),
+                methodDescriptor.getMethodDescriptor(),
                 null,
                 null);
 
@@ -278,17 +278,17 @@ public class PythonBytecodeToJavaBytecodeTranslator {
         String internalClassName = className.replace('.', '/');
         ClassWriter classWriter = new JavaPythonClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
         classWriter.visit(Opcodes.V11, Modifier.PUBLIC, internalClassName, null, Type.getInternalName(Object.class),
-                new String[] { methodDescriptor.declaringClassInternalName });
+                new String[] { methodDescriptor.getDeclaringClassInternalName() });
 
         final boolean isPythonLikeFunction =
-                methodDescriptor.declaringClassInternalName.equals(Type.getInternalName(PythonLikeFunction.class));
+                methodDescriptor.getDeclaringClassInternalName().equals(Type.getInternalName(PythonLikeFunction.class));
 
         createFields(classWriter);
         createConstructor(classWriter, internalClassName);
 
         MethodVisitor methodVisitor = classWriter.visitMethod(Modifier.PUBLIC,
-                methodDescriptor.methodName,
-                methodDescriptor.methodDescriptor,
+                methodDescriptor.getMethodName(),
+                methodDescriptor.getMethodDescriptor(),
                 null,
                 null);
 
@@ -296,9 +296,10 @@ public class PythonBytecodeToJavaBytecodeTranslator {
                 isPythonLikeFunction, Integer.MAX_VALUE, isVirtual); // TODO: Use actual python version
 
         String withoutGenericsSignature = Type.getMethodDescriptor(methodWithoutGenerics);
-        if (!withoutGenericsSignature.equals(methodDescriptor.methodDescriptor)) {
+        if (!withoutGenericsSignature.equals(methodDescriptor.getMethodDescriptor())) {
             methodVisitor =
-                    classWriter.visitMethod(Modifier.PUBLIC, methodDescriptor.methodName, withoutGenericsSignature, null, null);
+                    classWriter.visitMethod(Modifier.PUBLIC, methodDescriptor.getMethodName(), withoutGenericsSignature, null,
+                            null);
 
             methodVisitor.visitCode();
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
@@ -307,8 +308,8 @@ public class PythonBytecodeToJavaBytecodeTranslator {
                 methodVisitor.visitVarInsn(parameterType.getOpcode(Opcodes.ILOAD), i + 1);
                 methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, methodDescriptor.getParameterTypes()[i].getInternalName());
             }
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, internalClassName, methodDescriptor.methodName,
-                    methodDescriptor.methodDescriptor, false);
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, internalClassName, methodDescriptor.getMethodName(),
+                    methodDescriptor.getMethodDescriptor(), false);
             methodVisitor.visitInsn(methodDescriptor.getReturnType().getOpcode(Opcodes.IRETURN));
 
             methodVisitor.visitMaxs(-1, -1);
@@ -408,17 +409,17 @@ public class PythonBytecodeToJavaBytecodeTranslator {
         String internalClassName = className.replace('.', '/');
         ClassWriter classWriter = new JavaPythonClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
         classWriter.visit(Opcodes.V11, Modifier.PUBLIC, internalClassName, null, Type.getInternalName(Object.class),
-                new String[] { methodDescriptor.declaringClassInternalName });
+                new String[] { methodDescriptor.getDeclaringClassInternalName() });
 
         final boolean isPythonLikeFunction =
-                methodDescriptor.declaringClassInternalName.equals(Type.getInternalName(PythonLikeFunction.class));
+                methodDescriptor.getDeclaringClassInternalName().equals(Type.getInternalName(PythonLikeFunction.class));
 
         createFields(classWriter);
         createConstructor(classWriter, internalClassName);
 
         MethodVisitor methodVisitor = classWriter.visitMethod(Modifier.PUBLIC,
-                methodDescriptor.methodName,
-                methodDescriptor.methodDescriptor,
+                methodDescriptor.getMethodName(),
+                methodDescriptor.getMethodDescriptor(),
                 null,
                 null);
 
@@ -447,9 +448,10 @@ public class PythonBytecodeToJavaBytecodeTranslator {
                 pythonCompiledFunction); // TODO: Use actual python version
 
         String withoutGenericsSignature = Type.getMethodDescriptor(methodWithoutGenerics);
-        if (!withoutGenericsSignature.equals(methodDescriptor.methodDescriptor)) {
+        if (!withoutGenericsSignature.equals(methodDescriptor.getMethodDescriptor())) {
             methodVisitor =
-                    classWriter.visitMethod(Modifier.PUBLIC, methodDescriptor.methodName, withoutGenericsSignature, null, null);
+                    classWriter.visitMethod(Modifier.PUBLIC, methodDescriptor.getMethodName(), withoutGenericsSignature, null,
+                            null);
 
             methodVisitor.visitCode();
             methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
@@ -458,8 +460,8 @@ public class PythonBytecodeToJavaBytecodeTranslator {
                 methodVisitor.visitVarInsn(parameterType.getOpcode(Opcodes.ILOAD), i + 1);
                 methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, methodDescriptor.getParameterTypes()[i].getInternalName());
             }
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, internalClassName, methodDescriptor.methodName,
-                    methodDescriptor.methodDescriptor, false);
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, internalClassName, methodDescriptor.getMethodName(),
+                    methodDescriptor.getMethodDescriptor(), false);
             methodVisitor.visitInsn(methodDescriptor.getReturnType().getOpcode(Opcodes.IRETURN));
 
             methodVisitor.visitMaxs(-1, -1);

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonClassTranslator.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonClassTranslator.java
@@ -168,7 +168,7 @@ public class PythonClassTranslator {
             classWriter.visitField(Modifier.PUBLIC, getJavaFieldName(attributeName), javaFieldTypeDescriptor, null, null);
             FieldDescriptor fieldDescriptor =
                     new FieldDescriptor(attributeName, getJavaFieldName(attributeName), internalClassName,
-                            javaFieldTypeDescriptor, type);
+                            javaFieldTypeDescriptor, type, true);
             pythonLikeType.addInstanceField(fieldDescriptor);
         }
 

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonCompiledFunction.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonCompiledFunction.java
@@ -190,6 +190,11 @@ public class PythonCompiledFunction {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static <T> Class<T> getParameterJavaClass(List<PythonLikeType> parameterTypeList, int variableIndex) {
+        return (Class) parameterTypeList.get(variableIndex).getJavaClassOrDefault(PythonLikeObject.class);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public BiFunction<PythonLikeTuple, PythonLikeDict, ArgumentSpec<PythonLikeObject>> getArgumentSpecMapper() {
         return (defaultPositionalArguments, defaultKeywordArguments) -> {
             ArgumentSpec<PythonLikeObject> out = ArgumentSpec.forFunctionReturning(qualifiedName, getReturnType()
@@ -207,24 +212,23 @@ public class PythonCompiledFunction {
             for (; variableIndex < co_posonlyargcount; variableIndex++) {
                 if (variableIndex >= defaultPositionalStartIndex) {
                     out = out.addPositionalOnlyArgument(co_varnames.get(variableIndex),
-                            (Class) parameterTypeList.get(variableIndex)
-                                    .getJavaClassOrDefault(PythonLikeObject.class),
-                            defaultPositionalArguments.get(variableIndex - defaultPositionalStartIndex));
+                            getParameterJavaClass(parameterTypeList, variableIndex),
+                            defaultPositionalArguments.get(
+                                    variableIndex - defaultPositionalStartIndex));
                 } else {
                     out = out.addPositionalOnlyArgument(co_varnames.get(variableIndex),
-                            (Class) parameterTypeList.get(variableIndex)
-                                    .getJavaClassOrDefault(PythonLikeObject.class));
+                            getParameterJavaClass(parameterTypeList, variableIndex));
                 }
             }
 
             for (; variableIndex < co_argcount; variableIndex++) {
                 if (variableIndex >= defaultPositionalStartIndex) {
-                    out = out.addArgument(co_varnames.get(variableIndex), (Class) parameterTypeList.get(variableIndex)
-                            .getJavaClassOrDefault(PythonLikeObject.class),
+                    out = out.addArgument(co_varnames.get(variableIndex),
+                            getParameterJavaClass(parameterTypeList, variableIndex),
                             defaultPositionalArguments.get(variableIndex - defaultPositionalStartIndex));
                 } else {
-                    out = out.addArgument(co_varnames.get(variableIndex), (Class) parameterTypeList.get(variableIndex)
-                            .getJavaClassOrDefault(PythonLikeObject.class));
+                    out = out.addArgument(co_varnames.get(variableIndex),
+                            getParameterJavaClass(parameterTypeList, variableIndex));
                 }
             }
 
@@ -233,13 +237,11 @@ public class PythonCompiledFunction {
                         defaultKeywordArguments.get(PythonString.valueOf(co_varnames.get(variableIndex)));
                 if (maybeDefault != null) {
                     out = out.addKeywordOnlyArgument(co_varnames.get(variableIndex),
-                            (Class) parameterTypeList.get(variableIndex)
-                                    .getJavaClassOrDefault(PythonLikeObject.class),
+                            getParameterJavaClass(parameterTypeList, variableIndex),
                             maybeDefault);
                 } else {
                     out = out.addKeywordOnlyArgument(co_varnames.get(variableIndex),
-                            (Class) parameterTypeList.get(variableIndex)
-                                    .getJavaClassOrDefault(PythonLikeObject.class));
+                            getParameterJavaClass(parameterTypeList, variableIndex));
                 }
                 variableIndex++;
             }

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonDefaultArgumentImplementor.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonDefaultArgumentImplementor.java
@@ -76,8 +76,6 @@ public class PythonDefaultArgumentImplementor {
 
         final int defaultStart = methodDescriptor.getParameterTypes().length - defaultArgumentList.size();
         for (int i = 0; i < defaultArgumentList.size(); i++) {
-
-            PythonLikeObject value = defaultArgumentList.get(i);
             String fieldName = getConstantName(i);
             classWriter.visitField(Modifier.PUBLIC | Modifier.STATIC, fieldName,
                     methodDescriptor.getParameterTypes()[defaultStart + i].getDescriptor(),

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonDefaultArgumentImplementor.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonDefaultArgumentImplementor.java
@@ -52,9 +52,9 @@ public class PythonDefaultArgumentImplementor {
             Optional<Integer> extraKeywordArgumentsVariableIndex,
             ArgumentSpec<?> argumentSpec) {
         String maybeClassName = PythonBytecodeToJavaBytecodeTranslator.GENERATED_PACKAGE_BASE +
-                methodDescriptor.declaringClassInternalName.replace('/', '.') +
+                methodDescriptor.getDeclaringClassInternalName().replace('/', '.') +
                 "."
-                + methodDescriptor.methodName + "$$Defaults";
+                + methodDescriptor.getMethodName() + "$$Defaults";
         int numberOfInstances =
                 PythonBytecodeToJavaBytecodeTranslator.classNameToSharedInstanceCount.merge(maybeClassName, 1, Integer::sum);
         if (numberOfInstances > 1) {

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonFunctionSignature.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonFunctionSignature.java
@@ -3,6 +3,7 @@ package org.optaplanner.jpyinterpreter;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -10,36 +11,27 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
-import org.optaplanner.jpyinterpreter.implementors.CollectionImplementor;
 import org.optaplanner.jpyinterpreter.implementors.JavaPythonTypeConversionImplementor;
-import org.optaplanner.jpyinterpreter.implementors.StackManipulationImplementor;
-import org.optaplanner.jpyinterpreter.types.BoundPythonLikeFunction;
 import org.optaplanner.jpyinterpreter.types.BuiltinTypes;
 import org.optaplanner.jpyinterpreter.types.PythonLikeType;
-import org.optaplanner.jpyinterpreter.types.PythonString;
-import org.optaplanner.jpyinterpreter.types.collections.PythonLikeDict;
-import org.optaplanner.jpyinterpreter.types.collections.PythonLikeTuple;
 import org.optaplanner.jpyinterpreter.util.arguments.ArgumentSpec;
 
 public class PythonFunctionSignature {
-    final PythonLikeType returnType;
-    final PythonLikeType[] parameterTypes;
+    private final PythonLikeType returnType;
+    private final PythonLikeType[] parameterTypes;
 
-    final MethodDescriptor methodDescriptor;
+    private final MethodDescriptor methodDescriptor;
 
-    final List<PythonLikeObject> defaultArgumentList;
-    final Map<String, Integer> keywordToArgumentIndexMap;
+    private final List<PythonLikeObject> defaultArgumentList;
+    private final Map<String, Integer> keywordToArgumentIndexMap;
 
-    final Optional<Integer> extraPositionalArgumentsVariableIndex;
-    final Optional<Integer> extraKeywordArgumentsVariableIndex;
+    private final Optional<Integer> extraPositionalArgumentsVariableIndex;
+    private final Optional<Integer> extraKeywordArgumentsVariableIndex;
 
-    final Class<?> defaultArgumentHolderClass;
-    final ArgumentSpec<?> argumentSpec;
-    final boolean isFromArgumentSpec;
+    private final Class<?> defaultArgumentHolderClass;
+    private final ArgumentSpec<?> argumentSpec;
+    private final boolean isFromArgumentSpec;
 
     private static Map<String, Integer> extractKeywordArgument(MethodDescriptor methodDescriptor) {
         Map<String, Integer> out = new HashMap<>();
@@ -85,8 +77,8 @@ public class PythonFunctionSignature {
         isFromArgumentSpec = false;
         argumentSpec = computeArgumentSpec();
         defaultArgumentHolderClass = PythonDefaultArgumentImplementor.createDefaultArgumentFor(methodDescriptor,
-                defaultArgumentList, keywordToArgumentIndexMap, extraPositionalArgumentsVariableIndex,
-                extraKeywordArgumentsVariableIndex, argumentSpec);
+                defaultArgumentList, keywordToArgumentIndexMap, getExtraPositionalArgumentsVariableIndex(),
+                getExtraKeywordArgumentsVariableIndex(), getArgumentSpec());
 
     }
 
@@ -104,8 +96,8 @@ public class PythonFunctionSignature {
         isFromArgumentSpec = false;
         argumentSpec = computeArgumentSpec();
         defaultArgumentHolderClass = PythonDefaultArgumentImplementor.createDefaultArgumentFor(methodDescriptor,
-                defaultArgumentList, keywordToArgumentIndexMap, extraPositionalArgumentsVariableIndex,
-                extraKeywordArgumentsVariableIndex, argumentSpec);
+                defaultArgumentList, keywordToArgumentIndexMap, getExtraPositionalArgumentsVariableIndex(),
+                getExtraKeywordArgumentsVariableIndex(), getArgumentSpec());
     }
 
     public PythonFunctionSignature(MethodDescriptor methodDescriptor,
@@ -125,7 +117,7 @@ public class PythonFunctionSignature {
         argumentSpec = computeArgumentSpec();
         defaultArgumentHolderClass = PythonDefaultArgumentImplementor.createDefaultArgumentFor(methodDescriptor,
                 defaultArgumentList, keywordToArgumentIndexMap, extraPositionalArgumentsVariableIndex,
-                extraKeywordArgumentsVariableIndex, argumentSpec);
+                extraKeywordArgumentsVariableIndex, getArgumentSpec());
     }
 
     public PythonFunctionSignature(MethodDescriptor methodDescriptor,
@@ -151,66 +143,68 @@ public class PythonFunctionSignature {
 
     private ArgumentSpec<?> computeArgumentSpec() {
         try {
-            ArgumentSpec<?> argumentSpec = ArgumentSpec.forFunctionReturning(methodDescriptor.getMethodName(),
-                    (Class<? extends PythonLikeObject>) returnType.getJavaClass());
-            for (int i = 0; i < parameterTypes.length - defaultArgumentList.size(); i++) {
-                if (extraPositionalArgumentsVariableIndex.isPresent() && extraPositionalArgumentsVariableIndex.get() == i) {
+            ArgumentSpec<?> argumentSpec = ArgumentSpec.forFunctionReturning(getMethodDescriptor().getMethodName(),
+                    (Class<? extends PythonLikeObject>) getReturnType().getJavaClass());
+            for (int i = 0; i < getParameterTypes().length - getDefaultArgumentList().size(); i++) {
+                if (getExtraPositionalArgumentsVariableIndex().isPresent()
+                        && getExtraPositionalArgumentsVariableIndex().get() == i) {
                     continue;
                 }
 
-                if (extraKeywordArgumentsVariableIndex.isPresent() && extraKeywordArgumentsVariableIndex.get() == i) {
+                if (getExtraKeywordArgumentsVariableIndex().isPresent() && getExtraKeywordArgumentsVariableIndex().get() == i) {
                     continue;
                 }
 
                 final int argIndex = i;
-                Optional<String> argumentName = keywordToArgumentIndexMap.entrySet()
+                Optional<String> argumentName = getKeywordToArgumentIndexMap().entrySet()
                         .stream().filter(e -> e.getValue().equals(argIndex))
                         .map(Map.Entry::getKey)
                         .findAny();
 
                 if (argumentName.isEmpty()) {
                     argumentSpec = argumentSpec.addArgument("$arg" + i,
-                            (Class<? extends PythonLikeObject>) parameterTypes[i].getJavaClass());
+                            (Class<? extends PythonLikeObject>) getParameterTypes()[i].getJavaClass());
                 } else {
                     argumentSpec = argumentSpec.addArgument(argumentName.get(),
-                            (Class<? extends PythonLikeObject>) parameterTypes[i].getJavaClass());
+                            (Class<? extends PythonLikeObject>) getParameterTypes()[i].getJavaClass());
                 }
             }
 
-            for (int i = parameterTypes.length - defaultArgumentList.size(); i < parameterTypes.length; i++) {
-                if (extraPositionalArgumentsVariableIndex.isPresent() && extraPositionalArgumentsVariableIndex.get() == i) {
+            for (int i = getParameterTypes().length - getDefaultArgumentList().size(); i < getParameterTypes().length; i++) {
+                if (getExtraPositionalArgumentsVariableIndex().isPresent()
+                        && getExtraPositionalArgumentsVariableIndex().get() == i) {
                     continue;
                 }
 
-                if (extraKeywordArgumentsVariableIndex.isPresent() && extraKeywordArgumentsVariableIndex.get() == i) {
+                if (getExtraKeywordArgumentsVariableIndex().isPresent() && getExtraKeywordArgumentsVariableIndex().get() == i) {
                     continue;
                 }
 
                 PythonLikeObject defaultValue =
-                        defaultArgumentList.get(defaultArgumentList.size() - (parameterTypes.length - i));
+                        getDefaultArgumentList().get(getDefaultArgumentList().size() - (getParameterTypes().length - i));
 
                 final int argIndex = i;
-                Optional<String> argumentName = keywordToArgumentIndexMap.entrySet()
+                Optional<String> argumentName = getKeywordToArgumentIndexMap().entrySet()
                         .stream().filter(e -> e.getValue().equals(argIndex))
                         .map(Map.Entry::getKey)
                         .findAny();
 
                 if (argumentName.isEmpty()) {
                     argumentSpec = argumentSpec.addArgument("$arg" + i,
-                            (Class<PythonLikeObject>) parameterTypes[i].getJavaClass(),
+                            (Class<PythonLikeObject>) getParameterTypes()[i].getJavaClass(),
                             defaultValue);
                 } else {
                     argumentSpec = argumentSpec.addArgument(argumentName.get(),
-                            (Class<PythonLikeObject>) parameterTypes[i].getJavaClass(),
+                            (Class<PythonLikeObject>) getParameterTypes()[i].getJavaClass(),
                             defaultValue);
                 }
             }
 
-            if (extraPositionalArgumentsVariableIndex.isPresent()) {
+            if (getExtraPositionalArgumentsVariableIndex().isPresent()) {
                 argumentSpec = argumentSpec.addExtraPositionalVarArgument("*vargs");
             }
 
-            if (extraKeywordArgumentsVariableIndex.isPresent()) {
+            if (getExtraKeywordArgumentsVariableIndex().isPresent()) {
                 argumentSpec = argumentSpec.addExtraKeywordVarArgument("**kwargs");
             }
             return argumentSpec;
@@ -239,8 +233,28 @@ public class PythonFunctionSignature {
         return isFromArgumentSpec;
     }
 
+    public List<PythonLikeObject> getDefaultArgumentList() {
+        return defaultArgumentList;
+    }
+
+    public Map<String, Integer> getKeywordToArgumentIndexMap() {
+        return keywordToArgumentIndexMap;
+    }
+
+    public Optional<Integer> getExtraPositionalArgumentsVariableIndex() {
+        return extraPositionalArgumentsVariableIndex;
+    }
+
+    public Optional<Integer> getExtraKeywordArgumentsVariableIndex() {
+        return extraKeywordArgumentsVariableIndex;
+    }
+
+    public Class<?> getDefaultArgumentHolderClass() {
+        return defaultArgumentHolderClass;
+    }
+
     public boolean isVirtualMethod() {
-        switch (methodDescriptor.methodType) {
+        switch (getMethodDescriptor().getMethodType()) {
             case VIRTUAL:
             case INTERFACE:
             case CONSTRUCTOR:
@@ -252,60 +266,66 @@ public class PythonFunctionSignature {
     }
 
     public boolean isClassMethod() {
-        return methodDescriptor.methodType == MethodDescriptor.MethodType.CLASS;
+        return getMethodDescriptor().getMethodType() == MethodDescriptor.MethodType.CLASS;
     }
 
     public boolean isStaticMethod() {
-        return methodDescriptor.methodType == MethodDescriptor.MethodType.STATIC;
+        return getMethodDescriptor().getMethodType() == MethodDescriptor.MethodType.STATIC;
+    }
+
+    private int getPositionalParameterCount(int originalPositionalParameterCount) {
+        if (getMethodDescriptor().getMethodType() == MethodDescriptor.MethodType.CLASS) {
+            return originalPositionalParameterCount + 1;
+        } else {
+            return originalPositionalParameterCount;
+        }
+    }
+
+    private List<PythonLikeType> getCallParameterList(List<PythonLikeType> callStackTypeList) {
+        if (getMethodDescriptor().getMethodType() == MethodDescriptor.MethodType.CLASS) {
+            List<PythonLikeType> actualCallParameters = new ArrayList<>();
+            actualCallParameters.add(BuiltinTypes.TYPE_TYPE);
+            actualCallParameters.addAll(callStackTypeList);
+            return actualCallParameters;
+        } else {
+            return callStackTypeList;
+        }
     }
 
     public boolean matchesParameters(PythonLikeType... callParameters) {
-        if (methodDescriptor.methodType == MethodDescriptor.MethodType.CLASS) {
-            List<PythonLikeType> actualCallParameters = new ArrayList<>();
-            actualCallParameters.add(BuiltinTypes.TYPE_TYPE);
-            actualCallParameters.addAll(List.of(callParameters));
-            return argumentSpec.verifyMatchesCallSignature(callParameters.length + 1, List.of(),
-                    actualCallParameters);
-        } else {
-            return argumentSpec.verifyMatchesCallSignature(callParameters.length, List.of(),
-                    Arrays.asList(callParameters));
-        }
+        return getArgumentSpec().verifyMatchesCallSignature(getPositionalParameterCount(callParameters.length),
+                Collections.emptyList(),
+                getCallParameterList(List.of(callParameters)));
     }
 
     public boolean matchesParameters(int positionalArgumentCount, List<String> keywordArgumentNameList,
             List<PythonLikeType> callStackTypeList) {
-        if (methodDescriptor.methodType == MethodDescriptor.MethodType.CLASS) {
-            List<PythonLikeType> actualCallParameters = new ArrayList<>();
-            actualCallParameters.add(BuiltinTypes.TYPE_TYPE);
-            actualCallParameters.addAll(callStackTypeList);
-            return argumentSpec.verifyMatchesCallSignature(positionalArgumentCount + 1, keywordArgumentNameList,
-                    actualCallParameters);
-        } else {
-            return argumentSpec.verifyMatchesCallSignature(positionalArgumentCount, keywordArgumentNameList,
-                    callStackTypeList);
-        }
+
+        return getArgumentSpec().verifyMatchesCallSignature(getPositionalParameterCount(positionalArgumentCount),
+                keywordArgumentNameList,
+                getCallParameterList(callStackTypeList));
     }
 
     public boolean moreSpecificThan(PythonFunctionSignature other) {
-        if (other.parameterTypes.length < parameterTypes.length &&
-                (other.extraPositionalArgumentsVariableIndex.isPresent() ||
-                        other.extraKeywordArgumentsVariableIndex.isPresent())) {
+        if (other.getParameterTypes().length < getParameterTypes().length &&
+                (other.getExtraPositionalArgumentsVariableIndex().isPresent() ||
+                        other.getExtraKeywordArgumentsVariableIndex().isPresent())) {
             return true;
         }
 
-        if (other.parameterTypes.length > parameterTypes.length &&
-                (extraPositionalArgumentsVariableIndex.isPresent() ||
-                        extraKeywordArgumentsVariableIndex.isPresent())) {
+        if (other.getParameterTypes().length > getParameterTypes().length &&
+                (getExtraPositionalArgumentsVariableIndex().isPresent() ||
+                        getExtraKeywordArgumentsVariableIndex().isPresent())) {
             return false;
         }
 
-        if (other.parameterTypes.length != parameterTypes.length) {
+        if (other.getParameterTypes().length != getParameterTypes().length) {
             return false;
         }
 
-        for (int i = 0; i < parameterTypes.length; i++) {
-            PythonLikeType overloadParameterType = parameterTypes[i];
-            PythonLikeType otherParameterType = other.parameterTypes[i];
+        for (int i = 0; i < getParameterTypes().length; i++) {
+            PythonLikeType overloadParameterType = getParameterTypes()[i];
+            PythonLikeType otherParameterType = other.getParameterTypes()[i];
 
             if (otherParameterType.equals(overloadParameterType)) {
                 continue;
@@ -318,450 +338,6 @@ public class PythonFunctionSignature {
         return true;
     }
 
-    void unwrapBoundMethod(FunctionMetadata functionMetadata, StackMetadata stackMetadata, int posFromTOS) {
-        MethodVisitor methodVisitor = functionMetadata.methodVisitor;
-
-        if (methodDescriptor.methodType == MethodDescriptor.MethodType.VIRTUAL ||
-                methodDescriptor.methodType == MethodDescriptor.MethodType.INTERFACE) {
-            StackManipulationImplementor.duplicateToTOS(functionMetadata, stackMetadata, posFromTOS);
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
-                    "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
-                    false);
-            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, methodDescriptor.getDeclaringClassInternalName());
-            StackManipulationImplementor.shiftTOSDownBy(functionMetadata, stackMetadata, posFromTOS);
-        }
-    }
-
-    public void callMethod(MethodVisitor methodVisitor, LocalVariableHelper localVariableHelper, int argumentCount) {
-        if (isClassMethod()) {
-            // Class methods will also have their type/instance on the stack, but it not in argumentCount
-            argumentCount++;
-        }
-
-        int specPositionalArgumentCount = argumentSpec.getAllowPositionalArgumentCount();
-        int missingValues = Math.max(0, specPositionalArgumentCount - argumentCount);
-
-        int[] argumentLocals = new int[specPositionalArgumentCount];
-        int capturedExtraPositionalArgumentsLocal = localVariableHelper.newLocal();
-
-        // Create temporary variables for each argument
-        for (int i = 0; i < argumentLocals.length; i++) {
-            argumentLocals[i] = localVariableHelper.newLocal();
-        }
-
-        if (argumentSpec.hasExtraPositionalArgumentsCapture()) {
-            CollectionImplementor.buildCollection(PythonLikeTuple.class, methodVisitor,
-                    Math.max(0, argumentCount - specPositionalArgumentCount));
-            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeTuple.class),
-                    capturedExtraPositionalArgumentsLocal);
-        } else if (argumentCount > specPositionalArgumentCount) {
-            throw new IllegalStateException("Too many positional arguments given for argument spec " + argumentSpec);
-        }
-
-        // Call stack is in reverse, so TOS = argument (specPositionalArgumentCount - missingValues - 1)
-        // First store the variables into temporary local variables since we need to typecast them all
-        for (int i = specPositionalArgumentCount - missingValues - 1; i >= 0; i--) {
-            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class),
-                    argumentLocals[i]);
-        }
-
-        if (isVirtualMethod()) {
-            // If it is a virtual method, there will be self here, which we need to cast to the declaring class
-            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, methodDescriptor.getDeclaringClassInternalName());
-        }
-
-        if (isClassMethod()) {
-            // If it is a class method, argument 0 need to be converted to a type if it not a type
-            localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class),
-                    argumentLocals[0]);
-            methodVisitor.visitInsn(Opcodes.DUP);
-            Label ifIsBoundFunction = new Label();
-            Label doneGettingType = new Label();
-            methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(BoundPythonLikeFunction.class));
-            methodVisitor.visitJumpInsn(Opcodes.IFNE, ifIsBoundFunction);
-            methodVisitor.visitInsn(Opcodes.DUP);
-            methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(PythonLikeType.class));
-            methodVisitor.visitJumpInsn(Opcodes.IFNE, doneGettingType);
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
-                    true);
-            methodVisitor.visitJumpInsn(Opcodes.GOTO, doneGettingType);
-            methodVisitor.visitLabel(ifIsBoundFunction);
-            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(BoundPythonLikeFunction.class));
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
-                    "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
-                    false);
-            methodVisitor.visitLabel(doneGettingType);
-            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[0]);
-        }
-
-        // Now load and typecheck the local variables
-        for (int i = 0; i < Math.min(specPositionalArgumentCount, argumentCount); i++) {
-            localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[i]);
-            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(argumentSpec.getArgumentType(i)));
-        }
-
-        // Load any arguments missing values
-        for (int i = specPositionalArgumentCount - missingValues; i < specPositionalArgumentCount; i++) {
-            if (argumentSpec.isArgumentNullable(i)) {
-                methodVisitor.visitInsn(Opcodes.ACONST_NULL);
-            } else {
-                methodVisitor.visitFieldInsn(Opcodes.GETSTATIC, Type.getInternalName(defaultArgumentHolderClass),
-                        PythonDefaultArgumentImplementor.getConstantName(i),
-                        Type.getDescriptor(argumentSpec.getArgumentType(i)));
-            }
-        }
-
-        // Load *vargs and **kwargs if the function has them
-        if (argumentSpec.hasExtraPositionalArgumentsCapture()) {
-            localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeTuple.class),
-                    capturedExtraPositionalArgumentsLocal);
-        }
-
-        if (argumentSpec.hasExtraKeywordArgumentsCapture()) {
-            // No kwargs for call method, so just load an empty map
-            CollectionImplementor.buildMap(PythonLikeDict.class, methodVisitor, 0);
-        }
-
-        // Call the method
-        methodDescriptor.callMethod(methodVisitor);
-
-        // Free temporary locals for arguments
-        for (int i = 0; i < argumentLocals.length; i++) {
-            localVariableHelper.freeLocal();
-        }
-        // Free temporary local for vargs
-        localVariableHelper.freeLocal();
-    }
-
-    public void callPython311andAbove(FunctionMetadata functionMetadata, StackMetadata stackMetadata, int argumentCount,
-            List<String> keywordArgumentNameList) {
-        MethodVisitor methodVisitor = functionMetadata.methodVisitor;
-        LocalVariableHelper localVariableHelper = stackMetadata.localVariableHelper;
-
-        int specTotalArgumentCount = argumentSpec.getTotalArgumentCount();
-        int positionalArgumentCount = argumentCount - keywordArgumentNameList.size();
-        int[] argumentLocals = new int[specTotalArgumentCount];
-
-        // Create temporary variables for each argument
-        for (int i = 0; i < argumentLocals.length; i++) {
-            argumentLocals[i] = localVariableHelper.newLocal();
-        }
-        int extraKeywordArgumentsLocal = (argumentSpec.getExtraKeywordsArgumentIndex().isPresent())
-                ? argumentLocals[argumentSpec.getExtraKeywordsArgumentIndex().get()]
-                : -1;
-        int extraPositionalArgumentsLocal = (argumentSpec.getExtraPositionalsArgumentIndex().isPresent())
-                ? argumentLocals[argumentSpec.getExtraPositionalsArgumentIndex().get()]
-                : -1;
-
-        // Read keyword arguments
-        if (extraKeywordArgumentsLocal != -1) {
-            CollectionImplementor.buildMap(PythonLikeDict.class, methodVisitor, 0);
-            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeDict.class),
-                    extraKeywordArgumentsLocal);
-        }
-
-        // Read positional arguments
-        int positionalArgumentStart = (isClassMethod()) ? 1 : 0;
-
-        for (int keywordArgumentNameIndex =
-                keywordArgumentNameList.size() - 1; keywordArgumentNameIndex >= 0; keywordArgumentNameIndex--) {
-            // Need to iterate keyword name tuple in reverse (since last element of the tuple correspond to TOS)
-            String keywordArgument = keywordArgumentNameList.get(keywordArgumentNameIndex);
-            int argumentIndex = argumentSpec.getArgumentIndex(keywordArgument);
-            if (argumentIndex == -1) {
-                // Unknown keyword argument; put it into the extraKeywordArguments dict
-                localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeDict.class),
-                        extraKeywordArgumentsLocal);
-                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(PythonLikeDict.class));
-                methodVisitor.visitInsn(Opcodes.SWAP);
-                methodVisitor.visitLdcInsn(keywordArgument);
-                methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(PythonString.class),
-                        "valueOf", Type.getMethodDescriptor(Type.getType(PythonString.class),
-                                Type.getType(String.class)),
-                        false);
-                methodVisitor.visitInsn(Opcodes.SWAP);
-                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(PythonLikeDict.class),
-                        "put", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
-                                Type.getType(PythonLikeObject.class),
-                                Type.getType(PythonLikeObject.class)),
-                        false);
-            } else {
-                localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class),
-                        argumentLocals[argumentIndex]);
-            }
-        }
-
-        if (extraPositionalArgumentsLocal != -1) {
-            CollectionImplementor.buildCollection(PythonLikeTuple.class,
-                    methodVisitor,
-                    Math.max(0, positionalArgumentCount - argumentSpec.getAllowPositionalArgumentCount()
-                            + positionalArgumentStart));
-            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeTuple.class),
-                    extraPositionalArgumentsLocal);
-        }
-
-        for (int i = Math.min(positionalArgumentCount + positionalArgumentStart, argumentSpec.getAllowPositionalArgumentCount())
-                - 1; i >= positionalArgumentStart; i--) {
-            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class),
-                    argumentLocals[i]);
-        }
-
-        // Load missing arguments with default values
-        int defaultOffset = argumentSpec.getTotalArgumentCount() - defaultArgumentList.size();
-        for (int argumentIndex : argumentSpec.getUnspecifiedArgumentSet(positionalArgumentCount + positionalArgumentStart,
-                keywordArgumentNameList)) {
-            if (argumentSpec.isArgumentNullable(argumentIndex)) {
-                methodVisitor.visitInsn(Opcodes.ACONST_NULL);
-            } else {
-                methodVisitor.visitFieldInsn(Opcodes.GETSTATIC, Type.getInternalName(defaultArgumentHolderClass),
-                        PythonDefaultArgumentImplementor.getConstantName(argumentIndex - defaultOffset),
-                        Type.getDescriptor(argumentSpec.getArgumentType(argumentIndex)));
-            }
-            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class),
-                    argumentLocals[argumentIndex]);
-        }
-
-        if (isVirtualMethod()) {
-            // If it is a virtual method, there will be self here, which we need to cast to the declaring class
-            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, methodDescriptor.getDeclaringClassInternalName());
-        }
-
-        if (isClassMethod()) {
-            // If it is a class method, argument 0 need to be converted to a type if it not a type
-            methodVisitor.visitInsn(Opcodes.DUP);
-            Label ifIsBoundFunction = new Label();
-            Label doneGettingType = new Label();
-            methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(BoundPythonLikeFunction.class));
-            methodVisitor.visitJumpInsn(Opcodes.IFNE, ifIsBoundFunction);
-            methodVisitor.visitInsn(Opcodes.DUP);
-            methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(PythonLikeType.class));
-            methodVisitor.visitJumpInsn(Opcodes.IFNE, doneGettingType);
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
-                    true);
-            methodVisitor.visitJumpInsn(Opcodes.GOTO, doneGettingType);
-            methodVisitor.visitLabel(ifIsBoundFunction);
-            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(BoundPythonLikeFunction.class));
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
-                    "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
-                    false);
-            methodVisitor.visitLabel(doneGettingType);
-            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[0]);
-        }
-
-        // Load arguments in proper order and typecast them
-        for (int i = 0; i < specTotalArgumentCount; i++) {
-            localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[i]);
-            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(argumentSpec.getArgumentType(i)));
-        }
-
-        methodDescriptor.callMethod(methodVisitor);
-
-        // If it not a CLASS method, pop off the function object
-        // CLASS method consume the function object; Static and Virtual do not
-        if (!isClassMethod()) {
-            methodVisitor.visitInsn(Opcodes.SWAP);
-            methodVisitor.visitInsn(Opcodes.POP);
-        }
-
-        // Pop off NULL if it on the stack
-        if (stackMetadata.getTypeAtStackIndex(argumentCount + 1) == BuiltinTypes.NULL_TYPE) {
-            methodVisitor.visitInsn(Opcodes.SWAP);
-            methodVisitor.visitInsn(Opcodes.POP);
-        }
-
-        // Free temporary locals for arguments
-        for (int i = 0; i < argumentLocals.length; i++) {
-            localVariableHelper.freeLocal();
-        }
-    }
-
-    public void callWithoutKeywords(FunctionMetadata functionMetadata, StackMetadata stackMetadata, int argumentCount) {
-        MethodVisitor methodVisitor = functionMetadata.methodVisitor;
-
-        CollectionImplementor.buildCollection(PythonLikeTuple.class, methodVisitor, 0);
-        callWithKeywordsAndUnwrapSelf(functionMetadata, stackMetadata, argumentCount);
-    }
-
-    public void callWithKeywordsAndUnwrapSelf(FunctionMetadata functionMetadata, StackMetadata stackMetadata,
-            int argumentCount) {
-        callWithKeywords(functionMetadata, stackMetadata, argumentCount, true);
-    }
-
-    public void callWithKeywordsNoUnwrap(FunctionMetadata functionMetadata, StackMetadata stackMetadata,
-            int argumentCount) {
-        callWithKeywords(functionMetadata, stackMetadata, argumentCount, false);
-    }
-
-    private void callWithKeywords(FunctionMetadata functionMetadata, StackMetadata stackMetadata,
-            int argumentCount, boolean unwrapSelf) {
-        MethodVisitor methodVisitor = functionMetadata.methodVisitor;
-        Type[] descriptorParameterTypes = methodDescriptor.getParameterTypes();
-
-        if (argumentCount < descriptorParameterTypes.length && defaultArgumentHolderClass == null) {
-            throw new IllegalStateException("Cannot call " + this + " because there are not enough arguments");
-        }
-
-        if (argumentCount > descriptorParameterTypes.length && extraPositionalArgumentsVariableIndex.isEmpty()
-                && extraKeywordArgumentsVariableIndex.isEmpty()) {
-            throw new IllegalStateException("Cannot call " + this + " because there are too many arguments");
-        }
-
-        if (unwrapSelf) {
-            unwrapBoundMethod(functionMetadata, stackMetadata, argumentCount + 1);
-        }
-
-        if (!unwrapSelf && isClassMethod()) {
-            argumentCount++;
-        }
-
-        // TOS is a tuple of keys
-        methodVisitor.visitTypeInsn(Opcodes.NEW, Type.getInternalName(defaultArgumentHolderClass));
-        methodVisitor.visitInsn(Opcodes.DUP_X1);
-        methodVisitor.visitInsn(Opcodes.SWAP);
-
-        // Stack is defaults (uninitialized), keys
-
-        // Get position of last positional arg (= argumentCount - len(keys) - 1 )
-        methodVisitor.visitInsn(Opcodes.DUP); // dup keys
-        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(PythonLikeTuple.class), "size",
-                Type.getMethodDescriptor(Type.INT_TYPE), false);
-        methodVisitor.visitLdcInsn(argumentCount);
-        methodVisitor.visitInsn(Opcodes.SWAP);
-        methodVisitor.visitInsn(Opcodes.ISUB);
-
-        methodVisitor.visitInsn(Opcodes.ICONST_1);
-        methodVisitor.visitInsn(Opcodes.ISUB);
-
-        // Stack is defaults (uninitialized), keys, positional arguments
-        methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL, Type.getInternalName(defaultArgumentHolderClass),
-                "<init>", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(PythonLikeTuple.class), Type.INT_TYPE),
-                false);
-
-        for (int i = 0; i < argumentCount; i++) {
-            methodVisitor.visitInsn(Opcodes.DUP_X1);
-            methodVisitor.visitInsn(Opcodes.SWAP);
-            if (!unwrapSelf && isClassMethod() && i == argumentCount - 1) {
-                methodVisitor.visitInsn(Opcodes.DUP);
-                Label ifIsBoundFunction = new Label();
-                Label doneGettingType = new Label();
-                methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(BoundPythonLikeFunction.class));
-                methodVisitor.visitJumpInsn(Opcodes.IFNE, ifIsBoundFunction);
-                methodVisitor.visitInsn(Opcodes.DUP);
-                methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(PythonLikeType.class));
-                methodVisitor.visitJumpInsn(Opcodes.IFNE, doneGettingType);
-                methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
-                        "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
-                        true);
-                methodVisitor.visitJumpInsn(Opcodes.GOTO, doneGettingType);
-                methodVisitor.visitLabel(ifIsBoundFunction);
-                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(BoundPythonLikeFunction.class));
-                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
-                        "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
-                        false);
-                methodVisitor.visitLabel(doneGettingType);
-            }
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(defaultArgumentHolderClass),
-                    "addArgument", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(PythonLikeObject.class)),
-                    false);
-        }
-
-        for (int i = 0; i < descriptorParameterTypes.length; i++) {
-            methodVisitor.visitInsn(Opcodes.DUP);
-            methodVisitor.visitFieldInsn(Opcodes.GETFIELD, Type.getInternalName(defaultArgumentHolderClass),
-                    PythonDefaultArgumentImplementor.getArgumentName(i),
-                    descriptorParameterTypes[i].getDescriptor());
-            methodVisitor.visitInsn(Opcodes.SWAP);
-        }
-        methodVisitor.visitInsn(Opcodes.POP);
-
-        methodDescriptor.callMethod(methodVisitor);
-    }
-
-    public void callUnpackListAndMap(MethodVisitor methodVisitor) {
-        Type[] descriptorParameterTypes = methodDescriptor.getParameterTypes();
-
-        // TOS2 is the function to call, TOS1 is positional arguments, TOS is keyword arguments
-        if (methodDescriptor.methodType == MethodDescriptor.MethodType.CLASS) {
-            // stack is bound-method, pos, keywords
-            StackManipulationImplementor.rotateThree(methodVisitor);
-            // stack is keywords, bound-method, pos
-            StackManipulationImplementor.swap(methodVisitor);
-
-            // stack is keywords, pos, bound-method
-            methodVisitor.visitInsn(Opcodes.DUP_X2);
-
-            // stack is bound-method, keywords, pos, bound-method
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
-                    "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
-                    false);
-
-            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(PythonLikeType.class));
-            // stack is bound-method, keywords, pos, type
-
-            methodVisitor.visitInsn(Opcodes.DUP2);
-
-            // stack is bound-method, keywords, pos, type, pos, type
-            methodVisitor.visitInsn(Opcodes.ICONST_0);
-            methodVisitor.visitInsn(Opcodes.SWAP);
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(List.class), "add",
-                    Type.getMethodDescriptor(Type.VOID_TYPE, Type.INT_TYPE, Type.getType(Object.class)),
-                    true);
-            // stack is bound-method, keywords, pos, type
-            methodVisitor.visitInsn(Opcodes.POP);
-            methodVisitor.visitInsn(Opcodes.SWAP);
-
-            // stack is bound-method, pos, keywords
-        }
-
-        methodVisitor.visitFieldInsn(Opcodes.GETSTATIC, Type.getInternalName(defaultArgumentHolderClass),
-                PythonDefaultArgumentImplementor.ARGUMENT_SPEC_STATIC_FIELD_NAME,
-                Type.getDescriptor(ArgumentSpec.class));
-
-        methodVisitor.visitInsn(Opcodes.DUP_X2);
-        methodVisitor.visitInsn(Opcodes.POP);
-
-        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(ArgumentSpec.class),
-                "extractArgumentList", Type.getMethodDescriptor(Type.getType(List.class),
-                        Type.getType(List.class), Type.getType(Map.class)),
-                false);
-
-        // Stack is function to call, argument list
-        // Unwrap the bound method
-        if (methodDescriptor.methodType == MethodDescriptor.MethodType.VIRTUAL ||
-                methodDescriptor.methodType == MethodDescriptor.MethodType.INTERFACE) {
-            methodVisitor.visitInsn(Opcodes.SWAP);
-            methodVisitor.visitInsn(Opcodes.DUP_X1);
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
-                    "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
-                    false);
-
-            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, methodDescriptor.getDeclaringClassInternalName());
-            methodVisitor.visitInsn(Opcodes.SWAP);
-        }
-
-        // Stack is method, boundedInstance?, default
-
-        // Read the parameters
-        for (int i = 0; i < descriptorParameterTypes.length; i++) {
-            methodVisitor.visitInsn(Opcodes.DUP);
-            methodVisitor.visitLdcInsn(i);
-            methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(List.class),
-                    "get", Type.getMethodDescriptor(Type.getType(Object.class), Type.INT_TYPE),
-                    true);
-            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, descriptorParameterTypes[i].getInternalName());
-            methodVisitor.visitInsn(Opcodes.SWAP);
-        }
-        methodVisitor.visitInsn(Opcodes.POP);
-
-        // Stack is method, boundedInstance?, arg0, arg1, ...
-
-        methodDescriptor.callMethod(methodVisitor);
-
-        // Stack is method, result
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -771,22 +347,24 @@ public class PythonFunctionSignature {
             return false;
         }
         PythonFunctionSignature that = (PythonFunctionSignature) o;
-        return returnType.equals(that.returnType) && Arrays.equals(parameterTypes, that.parameterTypes) &&
-                extraPositionalArgumentsVariableIndex.equals(that.extraPositionalArgumentsVariableIndex) &&
-                extraKeywordArgumentsVariableIndex.equals(that.extraKeywordArgumentsVariableIndex);
+        return getReturnType().equals(that.getReturnType()) && Arrays.equals(getParameterTypes(), that.getParameterTypes()) &&
+                getExtraPositionalArgumentsVariableIndex().equals(that.getExtraPositionalArgumentsVariableIndex()) &&
+                getExtraKeywordArgumentsVariableIndex().equals(that.getExtraKeywordArgumentsVariableIndex());
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(returnType, extraPositionalArgumentsVariableIndex, extraKeywordArgumentsVariableIndex);
-        result = 31 * result + Arrays.hashCode(parameterTypes);
+        int result = Objects.hash(getReturnType(), getExtraPositionalArgumentsVariableIndex(),
+                getExtraKeywordArgumentsVariableIndex());
+        result = 31 * result + Arrays.hashCode(getParameterTypes());
         return result;
     }
 
     @Override
     public String toString() {
-        return methodDescriptor.getMethodName() +
-                Arrays.stream(parameterTypes).map(PythonLikeType::toString).collect(Collectors.joining(", ", "(", ") -> ")) +
-                returnType;
+        return getMethodDescriptor().getMethodName() +
+                Arrays.stream(getParameterTypes()).map(PythonLikeType::toString).collect(Collectors.joining(", ", "(", ") -> "))
+                +
+                getReturnType();
     }
 }

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonLikeObject.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/PythonLikeObject.java
@@ -66,6 +66,18 @@ public interface PythonLikeObject {
      */
     PythonLikeType __getType();
 
+    /**
+     * Return a generic version of {@link PythonLikeObject#__getType()}. This is used in bytecode
+     * generation and not at runtime. For example, for a list of integers, this return
+     * list[int], while getType returns list. Both methods are needed so type([1,2,3]) is type(['a', 'b', 'c'])
+     * return True.
+     *
+     * @return the generic version of this object's type. Must not be used in identity checks.
+     */
+    default PythonLikeType __getGenericType() {
+        return __getType();
+    }
+
     default PythonLikeObject $method$__getattribute__(PythonString pythonName) {
         String name = pythonName.value;
         PythonLikeObject objectResult = __getAttributeOrNull(name);

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/StackMetadata.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/StackMetadata.java
@@ -62,6 +62,11 @@ public class StackMetadata {
         return stackValueSources.size();
     }
 
+    public List<PythonLikeType> getStackTypeList() {
+        return stackValueSources.stream().map(ValueSourceInfo::getValueType)
+                .collect(Collectors.toList());
+    }
+
     /**
      * Returns the list index for the given stack index (stack index is how many
      * elements below TOS (i.e. 0 is TOS, 1 is TOS1)).

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/StackMetadata.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/StackMetadata.java
@@ -7,17 +7,52 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.optaplanner.jpyinterpreter.opcodes.OpcodeWithoutSource;
+import org.optaplanner.jpyinterpreter.types.BuiltinTypes;
 import org.optaplanner.jpyinterpreter.types.PythonLikeType;
 
 public class StackMetadata {
     public static final StackMetadata DEAD_CODE = new StackMetadata();
 
-    public LocalVariableHelper localVariableHelper;
-    public List<ValueSourceInfo> stackValueSources;
+    public final LocalVariableHelper localVariableHelper;
 
-    public List<ValueSourceInfo> localVariableValueSources;
+    private final List<ValueSourceInfo> stackValueSources;
+    private final List<ValueSourceInfo> localVariableValueSources;
+    private final List<ValueSourceInfo> cellVariableValueSources;
 
-    public List<ValueSourceInfo> cellVariableValueSources;
+    private List<String> callKeywordNameList;
+
+    private StackMetadata() {
+        this.localVariableHelper = null;
+        this.stackValueSources = null;
+        this.localVariableValueSources = null;
+        this.cellVariableValueSources = null;
+        this.callKeywordNameList = null;
+    }
+
+    public StackMetadata(LocalVariableHelper localVariableHelper) {
+        this.localVariableHelper = localVariableHelper;
+        this.stackValueSources = new ArrayList<>();
+        this.localVariableValueSources = new ArrayList<>(localVariableHelper.getNumberOfLocalVariables());
+        this.cellVariableValueSources = new ArrayList<>(localVariableHelper.getNumberOfCells());
+        for (int i = 0; i < localVariableHelper.getNumberOfLocalVariables(); i++) {
+            localVariableValueSources.add(null);
+        }
+        for (int i = 0; i < localVariableHelper.getNumberOfCells(); i++) {
+            cellVariableValueSources.add(ValueSourceInfo.of(new OpcodeWithoutSource(),
+                    BuiltinTypes.BASE_TYPE));
+        }
+        this.callKeywordNameList = List.of();
+    }
+
+    private StackMetadata(LocalVariableHelper localVariableHelper, List<ValueSourceInfo> stackValueSources,
+            List<ValueSourceInfo> localVariableValueSources, List<ValueSourceInfo> cellVariableValueSources,
+            List<String> callKeywordNameList) {
+        this.localVariableHelper = localVariableHelper;
+        this.stackValueSources = stackValueSources;
+        this.localVariableValueSources = localVariableValueSources;
+        this.cellVariableValueSources = cellVariableValueSources;
+        this.callKeywordNameList = callKeywordNameList;
+    }
 
     public boolean isDeadCode() {
         return this == DEAD_CODE;
@@ -133,11 +168,10 @@ public class StackMetadata {
     }
 
     public StackMetadata copy() {
-        StackMetadata out = new StackMetadata();
-        out.localVariableHelper = localVariableHelper;
-        out.stackValueSources = new ArrayList<>(stackValueSources);
-        out.localVariableValueSources = new ArrayList<>(localVariableValueSources);
-        out.cellVariableValueSources = new ArrayList<>(cellVariableValueSources);
+        StackMetadata out = new StackMetadata(localVariableHelper, new ArrayList<>(stackValueSources),
+                new ArrayList<>(localVariableValueSources),
+                new ArrayList<>(cellVariableValueSources),
+                callKeywordNameList);
         return out;
     }
 
@@ -310,6 +344,16 @@ public class StackMetadata {
     public StackMetadata setCellVariableValueSource(int index, ValueSourceInfo type) {
         StackMetadata out = copy();
         out.cellVariableValueSources.set(index, type);
+        return out;
+    }
+
+    public List<String> getCallKeywordNameList() {
+        return callKeywordNameList;
+    }
+
+    public StackMetadata setCallKeywordNameList(List<String> callKeywordNameList) {
+        StackMetadata out = copy();
+        out.callKeywordNameList = callKeywordNameList;
         return out;
     }
 

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/implementors/FunctionImplementor.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/implementors/FunctionImplementor.java
@@ -251,7 +251,6 @@ public class FunctionImplementor {
      * All of them are popped and the return value is pushed.
      */
     public static void call(FunctionMetadata functionMetadata, StackMetadata stackMetadata, int argumentCount) {
-        MethodVisitor methodVisitor = functionMetadata.methodVisitor;
         PythonLikeType functionType = stackMetadata.getTypeAtStackIndex(argumentCount + 1);
         if (functionType instanceof PythonLikeGenericType) {
             functionType = ((PythonLikeGenericType) functionType).getOrigin().getConstructorType().orElse(null);
@@ -266,7 +265,8 @@ public class FunctionImplementor {
                     .getFunctionForParameters(argumentCount - keywordArgumentNameList.size(), keywordArgumentNameList,
                             callStackParameterTypes)
                     .ifPresentOrElse(functionSignature -> {
-                        functionSignature.callPython311andAbove(functionMetadata, stackMetadata, argumentCount,
+                        KnownCallImplementor.callPython311andAbove(functionSignature, functionMetadata, stackMetadata,
+                                argumentCount,
                                 stackMetadata.getCallKeywordNameList());
                     }, () -> callGeneric(functionMetadata, stackMetadata, argumentCount));
         } else {
@@ -284,7 +284,8 @@ public class FunctionImplementor {
                         .getFunctionForParameters(argumentCount - keywordArgumentNameList.size(), keywordArgumentNameList,
                                 callStackParameterTypes)
                         .ifPresentOrElse(functionSignature -> {
-                            functionSignature.callPython311andAbove(functionMetadata, stackMetadata, argumentCount,
+                            KnownCallImplementor.callPython311andAbove(functionSignature, functionMetadata, stackMetadata,
+                                    argumentCount,
                                     stackMetadata.getCallKeywordNameList());
                         }, () -> callGeneric(functionMetadata, stackMetadata, argumentCount));
             } else {
@@ -395,7 +396,7 @@ public class FunctionImplementor {
             }
             knownFunctionType.getFunctionForParameters(parameterTypes)
                     .ifPresentOrElse(functionSignature -> {
-                        functionSignature.callMethod(methodVisitor, localVariableHelper, instruction.arg);
+                        KnownCallImplementor.callMethod(functionSignature, methodVisitor, localVariableHelper, instruction.arg);
                         methodVisitor.visitInsn(Opcodes.SWAP);
                         methodVisitor.visitInsn(Opcodes.POP);
                         if (knownFunctionType.isStaticMethod()) {
@@ -484,7 +485,7 @@ public class FunctionImplementor {
             PythonKnownFunctionType knownFunctionType = (PythonKnownFunctionType) functionType;
             knownFunctionType.getDefaultFunctionSignature()
                     .ifPresentOrElse(functionSignature -> {
-                        functionSignature.callWithoutKeywords(functionMetadata, stackMetadata,
+                        KnownCallImplementor.callWithoutKeywords(functionSignature, functionMetadata, stackMetadata,
                                 instruction.arg);
                         methodVisitor.visitInsn(Opcodes.SWAP);
                         methodVisitor.visitInsn(Opcodes.POP);
@@ -554,7 +555,7 @@ public class FunctionImplementor {
             PythonKnownFunctionType knownFunctionType = (PythonKnownFunctionType) functionType;
             knownFunctionType.getDefaultFunctionSignature()
                     .ifPresentOrElse(functionSignature -> {
-                        functionSignature.callWithKeywordsAndUnwrapSelf(functionMetadata, stackMetadata,
+                        KnownCallImplementor.callWithKeywordsAndUnwrapSelf(functionSignature, functionMetadata, stackMetadata,
                                 instruction.arg);
                         methodVisitor.visitInsn(Opcodes.SWAP);
                         methodVisitor.visitInsn(Opcodes.POP);

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/implementors/FunctionImplementor.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/implementors/FunctionImplementor.java
@@ -253,6 +253,9 @@ public class FunctionImplementor {
     public static void call(FunctionMetadata functionMetadata, StackMetadata stackMetadata, int argumentCount) {
         MethodVisitor methodVisitor = functionMetadata.methodVisitor;
         PythonLikeType functionType = stackMetadata.getTypeAtStackIndex(argumentCount + 1);
+        if (functionType instanceof PythonLikeGenericType) {
+            functionType = ((PythonLikeGenericType) functionType).getOrigin().getConstructorType().orElse(null);
+        }
         if (functionType instanceof PythonKnownFunctionType) {
             PythonKnownFunctionType knownFunctionType = (PythonKnownFunctionType) functionType;
             List<String> keywordArgumentNameList = stackMetadata.getCallKeywordNameList();
@@ -265,11 +268,12 @@ public class FunctionImplementor {
                     .ifPresentOrElse(functionSignature -> {
                         functionSignature.callPython311andAbove(functionMetadata, stackMetadata, argumentCount,
                                 stackMetadata.getCallKeywordNameList());
-                        methodVisitor.visitInsn(Opcodes.SWAP);
-                        methodVisitor.visitInsn(Opcodes.POP);
                     }, () -> callGeneric(functionMetadata, stackMetadata, argumentCount));
         } else {
             functionType = stackMetadata.getTypeAtStackIndex(argumentCount);
+            if (functionType instanceof PythonLikeGenericType) {
+                functionType = ((PythonLikeGenericType) functionType).getOrigin().getConstructorType().orElse(null);
+            }
             if (functionType instanceof PythonKnownFunctionType) {
                 PythonKnownFunctionType knownFunctionType = (PythonKnownFunctionType) functionType;
                 List<String> keywordArgumentNameList = stackMetadata.getCallKeywordNameList();
@@ -282,8 +286,6 @@ public class FunctionImplementor {
                         .ifPresentOrElse(functionSignature -> {
                             functionSignature.callPython311andAbove(functionMetadata, stackMetadata, argumentCount,
                                     stackMetadata.getCallKeywordNameList());
-                            methodVisitor.visitInsn(Opcodes.SWAP);
-                            methodVisitor.visitInsn(Opcodes.POP);
                         }, () -> callGeneric(functionMetadata, stackMetadata, argumentCount));
             } else {
                 callGeneric(functionMetadata, stackMetadata, argumentCount);

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/implementors/KnownCallImplementor.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/implementors/KnownCallImplementor.java
@@ -1,0 +1,493 @@
+package org.optaplanner.jpyinterpreter.implementors;
+
+import java.util.List;
+import java.util.Map;
+
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.optaplanner.jpyinterpreter.FunctionMetadata;
+import org.optaplanner.jpyinterpreter.LocalVariableHelper;
+import org.optaplanner.jpyinterpreter.MethodDescriptor;
+import org.optaplanner.jpyinterpreter.PythonDefaultArgumentImplementor;
+import org.optaplanner.jpyinterpreter.PythonFunctionSignature;
+import org.optaplanner.jpyinterpreter.PythonLikeObject;
+import org.optaplanner.jpyinterpreter.StackMetadata;
+import org.optaplanner.jpyinterpreter.types.BoundPythonLikeFunction;
+import org.optaplanner.jpyinterpreter.types.BuiltinTypes;
+import org.optaplanner.jpyinterpreter.types.PythonLikeType;
+import org.optaplanner.jpyinterpreter.types.PythonString;
+import org.optaplanner.jpyinterpreter.types.collections.PythonLikeDict;
+import org.optaplanner.jpyinterpreter.types.collections.PythonLikeTuple;
+import org.optaplanner.jpyinterpreter.util.arguments.ArgumentSpec;
+
+/**
+ * Implements function calls when the function being called is known.
+ */
+public class KnownCallImplementor {
+
+    static void unwrapBoundMethod(PythonFunctionSignature pythonFunctionSignature, FunctionMetadata functionMetadata,
+            StackMetadata stackMetadata, int posFromTOS) {
+        MethodVisitor methodVisitor = functionMetadata.methodVisitor;
+
+        if (pythonFunctionSignature.getMethodDescriptor().getMethodType() == MethodDescriptor.MethodType.VIRTUAL ||
+                pythonFunctionSignature.getMethodDescriptor().getMethodType() == MethodDescriptor.MethodType.INTERFACE) {
+            StackManipulationImplementor.duplicateToTOS(functionMetadata, stackMetadata, posFromTOS);
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
+                    "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
+                    false);
+            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
+                    pythonFunctionSignature.getMethodDescriptor().getDeclaringClassInternalName());
+            StackManipulationImplementor.shiftTOSDownBy(functionMetadata, stackMetadata, posFromTOS);
+        }
+    }
+
+    public static void callMethod(PythonFunctionSignature pythonFunctionSignature, MethodVisitor methodVisitor,
+            LocalVariableHelper localVariableHelper, int argumentCount) {
+        if (pythonFunctionSignature.isClassMethod()) {
+            // Class methods will also have their type/instance on the stack, but it not in argumentCount
+            argumentCount++;
+        }
+
+        int specPositionalArgumentCount = pythonFunctionSignature.getArgumentSpec().getAllowPositionalArgumentCount();
+        int missingValues = Math.max(0, specPositionalArgumentCount - argumentCount);
+
+        int[] argumentLocals = new int[specPositionalArgumentCount];
+        int capturedExtraPositionalArgumentsLocal = localVariableHelper.newLocal();
+
+        // Create temporary variables for each argument
+        for (int i = 0; i < argumentLocals.length; i++) {
+            argumentLocals[i] = localVariableHelper.newLocal();
+        }
+
+        if (pythonFunctionSignature.getArgumentSpec().hasExtraPositionalArgumentsCapture()) {
+            CollectionImplementor.buildCollection(PythonLikeTuple.class, methodVisitor,
+                    Math.max(0, argumentCount - specPositionalArgumentCount));
+            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeTuple.class),
+                    capturedExtraPositionalArgumentsLocal);
+        } else if (argumentCount > specPositionalArgumentCount) {
+            throw new IllegalStateException(
+                    "Too many positional arguments given for argument spec " + pythonFunctionSignature.getArgumentSpec());
+        }
+
+        // Call stack is in reverse, so TOS = argument (specPositionalArgumentCount - missingValues - 1)
+        // First store the variables into temporary local variables since we need to typecast them all
+        for (int i = specPositionalArgumentCount - missingValues - 1; i >= 0; i--) {
+            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class),
+                    argumentLocals[i]);
+        }
+
+        if (pythonFunctionSignature.isVirtualMethod()) {
+            // If it is a virtual method, there will be self here, which we need to cast to the declaring class
+            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
+                    pythonFunctionSignature.getMethodDescriptor().getDeclaringClassInternalName());
+        }
+
+        if (pythonFunctionSignature.isClassMethod()) {
+            // If it is a class method, argument 0 need to be converted to a type if it not a type
+            localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class),
+                    argumentLocals[0]);
+            methodVisitor.visitInsn(Opcodes.DUP);
+            Label ifIsBoundFunction = new Label();
+            Label doneGettingType = new Label();
+            methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(BoundPythonLikeFunction.class));
+            methodVisitor.visitJumpInsn(Opcodes.IFNE, ifIsBoundFunction);
+            methodVisitor.visitInsn(Opcodes.DUP);
+            methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(PythonLikeType.class));
+            methodVisitor.visitJumpInsn(Opcodes.IFNE, doneGettingType);
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
+                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                    true);
+            methodVisitor.visitJumpInsn(Opcodes.GOTO, doneGettingType);
+            methodVisitor.visitLabel(ifIsBoundFunction);
+            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(BoundPythonLikeFunction.class));
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
+                    "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
+                    false);
+            methodVisitor.visitLabel(doneGettingType);
+            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[0]);
+        }
+
+        // Now load and typecheck the local variables
+        for (int i = 0; i < Math.min(specPositionalArgumentCount, argumentCount); i++) {
+            localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[i]);
+            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
+                    Type.getInternalName(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
+        }
+
+        // Load any arguments missing values
+        for (int i = specPositionalArgumentCount - missingValues; i < specPositionalArgumentCount; i++) {
+            if (pythonFunctionSignature.getArgumentSpec().isArgumentNullable(i)) {
+                methodVisitor.visitInsn(Opcodes.ACONST_NULL);
+            } else {
+                methodVisitor.visitFieldInsn(Opcodes.GETSTATIC,
+                        Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()),
+                        PythonDefaultArgumentImplementor.getConstantName(i),
+                        Type.getDescriptor(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
+            }
+        }
+
+        // Load *vargs and **kwargs if the function has them
+        if (pythonFunctionSignature.getArgumentSpec().hasExtraPositionalArgumentsCapture()) {
+            localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeTuple.class),
+                    capturedExtraPositionalArgumentsLocal);
+        }
+
+        if (pythonFunctionSignature.getArgumentSpec().hasExtraKeywordArgumentsCapture()) {
+            // No kwargs for call method, so just load an empty map
+            CollectionImplementor.buildMap(PythonLikeDict.class, methodVisitor, 0);
+        }
+
+        // Call the method
+        pythonFunctionSignature.getMethodDescriptor().callMethod(methodVisitor);
+
+        // Free temporary locals for arguments
+        for (int i = 0; i < argumentLocals.length; i++) {
+            localVariableHelper.freeLocal();
+        }
+        // Free temporary local for vargs
+        localVariableHelper.freeLocal();
+    }
+
+    public static void callPython311andAbove(PythonFunctionSignature pythonFunctionSignature, FunctionMetadata functionMetadata,
+            StackMetadata stackMetadata, int argumentCount,
+            List<String> keywordArgumentNameList) {
+        MethodVisitor methodVisitor = functionMetadata.methodVisitor;
+        LocalVariableHelper localVariableHelper = stackMetadata.localVariableHelper;
+
+        int specTotalArgumentCount = pythonFunctionSignature.getArgumentSpec().getTotalArgumentCount();
+        int positionalArgumentCount = argumentCount - keywordArgumentNameList.size();
+        int[] argumentLocals = new int[specTotalArgumentCount];
+
+        // Create temporary variables for each argument
+        for (int i = 0; i < argumentLocals.length; i++) {
+            argumentLocals[i] = localVariableHelper.newLocal();
+        }
+        int extraKeywordArgumentsLocal = (pythonFunctionSignature.getArgumentSpec().getExtraKeywordsArgumentIndex().isPresent())
+                ? argumentLocals[pythonFunctionSignature.getArgumentSpec().getExtraKeywordsArgumentIndex().get()]
+                : -1;
+        int extraPositionalArgumentsLocal =
+                (pythonFunctionSignature.getArgumentSpec().getExtraPositionalsArgumentIndex().isPresent())
+                        ? argumentLocals[pythonFunctionSignature.getArgumentSpec().getExtraPositionalsArgumentIndex().get()]
+                        : -1;
+
+        // Read keyword arguments
+        if (extraKeywordArgumentsLocal != -1) {
+            CollectionImplementor.buildMap(PythonLikeDict.class, methodVisitor, 0);
+            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeDict.class),
+                    extraKeywordArgumentsLocal);
+        }
+
+        // Read positional arguments
+        int positionalArgumentStart = (pythonFunctionSignature.isClassMethod()) ? 1 : 0;
+
+        for (int keywordArgumentNameIndex =
+                keywordArgumentNameList.size() - 1; keywordArgumentNameIndex >= 0; keywordArgumentNameIndex--) {
+            // Need to iterate keyword name tuple in reverse (since last element of the tuple correspond to TOS)
+            String keywordArgument = keywordArgumentNameList.get(keywordArgumentNameIndex);
+            int argumentIndex = pythonFunctionSignature.getArgumentSpec().getArgumentIndex(keywordArgument);
+            if (argumentIndex == -1) {
+                // Unknown keyword argument; put it into the extraKeywordArguments dict
+                localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeDict.class),
+                        extraKeywordArgumentsLocal);
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(PythonLikeDict.class));
+                methodVisitor.visitInsn(Opcodes.SWAP);
+                methodVisitor.visitLdcInsn(keywordArgument);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, Type.getInternalName(PythonString.class),
+                        "valueOf", Type.getMethodDescriptor(Type.getType(PythonString.class),
+                                Type.getType(String.class)),
+                        false);
+                methodVisitor.visitInsn(Opcodes.SWAP);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(PythonLikeDict.class),
+                        "put", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class),
+                                Type.getType(PythonLikeObject.class),
+                                Type.getType(PythonLikeObject.class)),
+                        false);
+            } else {
+                localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class),
+                        argumentLocals[argumentIndex]);
+            }
+        }
+
+        if (extraPositionalArgumentsLocal != -1) {
+            CollectionImplementor.buildCollection(PythonLikeTuple.class,
+                    methodVisitor,
+                    Math.max(0,
+                            positionalArgumentCount
+                                    - pythonFunctionSignature.getArgumentSpec().getAllowPositionalArgumentCount()
+                                    + positionalArgumentStart));
+            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeTuple.class),
+                    extraPositionalArgumentsLocal);
+        }
+
+        for (int i = Math.min(positionalArgumentCount + positionalArgumentStart,
+                pythonFunctionSignature.getArgumentSpec().getAllowPositionalArgumentCount())
+                - 1; i >= positionalArgumentStart; i--) {
+            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class),
+                    argumentLocals[i]);
+        }
+
+        // Load missing arguments with default values
+        int defaultOffset = pythonFunctionSignature.getArgumentSpec().getTotalArgumentCount()
+                - pythonFunctionSignature.getDefaultArgumentList().size();
+        for (int argumentIndex : pythonFunctionSignature.getArgumentSpec().getUnspecifiedArgumentSet(
+                positionalArgumentCount + positionalArgumentStart,
+                keywordArgumentNameList)) {
+            if (pythonFunctionSignature.getArgumentSpec().isArgumentNullable(argumentIndex)) {
+                methodVisitor.visitInsn(Opcodes.ACONST_NULL);
+            } else {
+                methodVisitor.visitFieldInsn(Opcodes.GETSTATIC,
+                        Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()),
+                        PythonDefaultArgumentImplementor.getConstantName(argumentIndex - defaultOffset),
+                        Type.getDescriptor(pythonFunctionSignature.getArgumentSpec().getArgumentType(argumentIndex)));
+            }
+            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class),
+                    argumentLocals[argumentIndex]);
+        }
+
+        if (pythonFunctionSignature.isVirtualMethod()) {
+            // If it is a virtual method, there will be self here, which we need to cast to the declaring class
+            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
+                    pythonFunctionSignature.getMethodDescriptor().getDeclaringClassInternalName());
+        }
+
+        if (pythonFunctionSignature.isClassMethod()) {
+            // If it is a class method, argument 0 need to be converted to a type if it not a type
+            methodVisitor.visitInsn(Opcodes.DUP);
+            Label ifIsBoundFunction = new Label();
+            Label doneGettingType = new Label();
+            methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(BoundPythonLikeFunction.class));
+            methodVisitor.visitJumpInsn(Opcodes.IFNE, ifIsBoundFunction);
+            methodVisitor.visitInsn(Opcodes.DUP);
+            methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(PythonLikeType.class));
+            methodVisitor.visitJumpInsn(Opcodes.IFNE, doneGettingType);
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
+                    "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                    true);
+            methodVisitor.visitJumpInsn(Opcodes.GOTO, doneGettingType);
+            methodVisitor.visitLabel(ifIsBoundFunction);
+            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(BoundPythonLikeFunction.class));
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
+                    "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
+                    false);
+            methodVisitor.visitLabel(doneGettingType);
+            localVariableHelper.writeTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[0]);
+        }
+
+        // Load arguments in proper order and typecast them
+        for (int i = 0; i < specTotalArgumentCount; i++) {
+            localVariableHelper.readTemp(methodVisitor, Type.getType(PythonLikeObject.class), argumentLocals[i]);
+            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST,
+                    Type.getInternalName(pythonFunctionSignature.getArgumentSpec().getArgumentType(i)));
+        }
+
+        pythonFunctionSignature.getMethodDescriptor().callMethod(methodVisitor);
+
+        // If it not a CLASS method, pop off the function object
+        // CLASS method consume the function object; Static and Virtual do not
+        if (!pythonFunctionSignature.isClassMethod()) {
+            methodVisitor.visitInsn(Opcodes.SWAP);
+            methodVisitor.visitInsn(Opcodes.POP);
+        }
+
+        // Pop off NULL if it on the stack
+        if (stackMetadata.getTypeAtStackIndex(argumentCount + 1) == BuiltinTypes.NULL_TYPE) {
+            methodVisitor.visitInsn(Opcodes.SWAP);
+            methodVisitor.visitInsn(Opcodes.POP);
+        }
+
+        // Free temporary locals for arguments
+        for (int i = 0; i < argumentLocals.length; i++) {
+            localVariableHelper.freeLocal();
+        }
+    }
+
+    public static void callWithoutKeywords(PythonFunctionSignature pythonFunctionSignature, FunctionMetadata functionMetadata,
+            StackMetadata stackMetadata, int argumentCount) {
+        MethodVisitor methodVisitor = functionMetadata.methodVisitor;
+
+        CollectionImplementor.buildCollection(PythonLikeTuple.class, methodVisitor, 0);
+        callWithKeywordsAndUnwrapSelf(pythonFunctionSignature, functionMetadata, stackMetadata, argumentCount);
+    }
+
+    public static void callWithKeywordsAndUnwrapSelf(PythonFunctionSignature pythonFunctionSignature,
+            FunctionMetadata functionMetadata, StackMetadata stackMetadata,
+            int argumentCount) {
+        callWithKeywords(pythonFunctionSignature, functionMetadata, stackMetadata, argumentCount);
+    }
+
+    private static void callWithKeywords(PythonFunctionSignature pythonFunctionSignature, FunctionMetadata functionMetadata,
+            StackMetadata stackMetadata,
+            int argumentCount) {
+        MethodVisitor methodVisitor = functionMetadata.methodVisitor;
+        Type[] descriptorParameterTypes = pythonFunctionSignature.getMethodDescriptor().getParameterTypes();
+
+        if (argumentCount < descriptorParameterTypes.length
+                && pythonFunctionSignature.getDefaultArgumentHolderClass() == null) {
+            throw new IllegalStateException(
+                    "Cannot call " + pythonFunctionSignature + " because there are not enough arguments");
+        }
+
+        if (argumentCount > descriptorParameterTypes.length
+                && pythonFunctionSignature.getExtraPositionalArgumentsVariableIndex().isEmpty()
+                && pythonFunctionSignature.getExtraKeywordArgumentsVariableIndex().isEmpty()) {
+            throw new IllegalStateException("Cannot call " + pythonFunctionSignature + " because there are too many arguments");
+        }
+
+        unwrapBoundMethod(pythonFunctionSignature, functionMetadata, stackMetadata, argumentCount + 1);
+
+        if (pythonFunctionSignature.isClassMethod()) {
+            argumentCount++;
+        }
+
+        // TOS is a tuple of keys
+        methodVisitor.visitTypeInsn(Opcodes.NEW, Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()));
+        methodVisitor.visitInsn(Opcodes.DUP_X1);
+        methodVisitor.visitInsn(Opcodes.SWAP);
+
+        // Stack is defaults (uninitialized), keys
+
+        // Get position of last positional arg (= argumentCount - len(keys) - 1 )
+        methodVisitor.visitInsn(Opcodes.DUP); // dup keys
+        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(PythonLikeTuple.class), "size",
+                Type.getMethodDescriptor(Type.INT_TYPE), false);
+        methodVisitor.visitLdcInsn(argumentCount);
+        methodVisitor.visitInsn(Opcodes.SWAP);
+        methodVisitor.visitInsn(Opcodes.ISUB);
+
+        methodVisitor.visitInsn(Opcodes.ICONST_1);
+        methodVisitor.visitInsn(Opcodes.ISUB);
+
+        // Stack is defaults (uninitialized), keys, positional arguments
+        methodVisitor.visitMethodInsn(Opcodes.INVOKESPECIAL,
+                Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()),
+                "<init>", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(PythonLikeTuple.class), Type.INT_TYPE),
+                false);
+
+        for (int i = 0; i < argumentCount; i++) {
+            methodVisitor.visitInsn(Opcodes.DUP_X1);
+            methodVisitor.visitInsn(Opcodes.SWAP);
+            if (pythonFunctionSignature.isClassMethod() && i == argumentCount - 1) {
+                methodVisitor.visitInsn(Opcodes.DUP);
+                Label ifIsBoundFunction = new Label();
+                Label doneGettingType = new Label();
+                methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(BoundPythonLikeFunction.class));
+                methodVisitor.visitJumpInsn(Opcodes.IFNE, ifIsBoundFunction);
+                methodVisitor.visitInsn(Opcodes.DUP);
+                methodVisitor.visitTypeInsn(Opcodes.INSTANCEOF, Type.getInternalName(PythonLikeType.class));
+                methodVisitor.visitJumpInsn(Opcodes.IFNE, doneGettingType);
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(PythonLikeObject.class),
+                        "__getType", Type.getMethodDescriptor(Type.getType(PythonLikeType.class)),
+                        true);
+                methodVisitor.visitJumpInsn(Opcodes.GOTO, doneGettingType);
+                methodVisitor.visitLabel(ifIsBoundFunction);
+                methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(BoundPythonLikeFunction.class));
+                methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
+                        "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
+                        false);
+                methodVisitor.visitLabel(doneGettingType);
+            }
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                    Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()),
+                    "addArgument", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(PythonLikeObject.class)),
+                    false);
+        }
+
+        for (int i = 0; i < descriptorParameterTypes.length; i++) {
+            methodVisitor.visitInsn(Opcodes.DUP);
+            methodVisitor.visitFieldInsn(Opcodes.GETFIELD,
+                    Type.getInternalName(pythonFunctionSignature.getDefaultArgumentHolderClass()),
+                    PythonDefaultArgumentImplementor.getArgumentName(i),
+                    descriptorParameterTypes[i].getDescriptor());
+            methodVisitor.visitInsn(Opcodes.SWAP);
+        }
+        methodVisitor.visitInsn(Opcodes.POP);
+
+        pythonFunctionSignature.getMethodDescriptor().callMethod(methodVisitor);
+    }
+
+    public static void callUnpackListAndMap(Class<?> defaultArgumentHolderClass, MethodDescriptor methodDescriptor,
+            MethodVisitor methodVisitor) {
+        Type[] descriptorParameterTypes = methodDescriptor.getParameterTypes();
+
+        // TOS2 is the function to call, TOS1 is positional arguments, TOS is keyword arguments
+        if (methodDescriptor.getMethodType() == MethodDescriptor.MethodType.CLASS) {
+            // stack is bound-method, pos, keywords
+            StackManipulationImplementor.rotateThree(methodVisitor);
+            // stack is keywords, bound-method, pos
+            StackManipulationImplementor.swap(methodVisitor);
+
+            // stack is keywords, pos, bound-method
+            methodVisitor.visitInsn(Opcodes.DUP_X2);
+
+            // stack is bound-method, keywords, pos, bound-method
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
+                    "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
+                    false);
+
+            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(PythonLikeType.class));
+            // stack is bound-method, keywords, pos, type
+
+            methodVisitor.visitInsn(Opcodes.DUP2);
+
+            // stack is bound-method, keywords, pos, type, pos, type
+            methodVisitor.visitInsn(Opcodes.ICONST_0);
+            methodVisitor.visitInsn(Opcodes.SWAP);
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(List.class), "add",
+                    Type.getMethodDescriptor(Type.VOID_TYPE, Type.INT_TYPE, Type.getType(Object.class)),
+                    true);
+            // stack is bound-method, keywords, pos, type
+            methodVisitor.visitInsn(Opcodes.POP);
+            methodVisitor.visitInsn(Opcodes.SWAP);
+
+            // stack is bound-method, pos, keywords
+        }
+
+        methodVisitor.visitFieldInsn(Opcodes.GETSTATIC, Type.getInternalName(defaultArgumentHolderClass),
+                PythonDefaultArgumentImplementor.ARGUMENT_SPEC_STATIC_FIELD_NAME,
+                Type.getDescriptor(ArgumentSpec.class));
+
+        methodVisitor.visitInsn(Opcodes.DUP_X2);
+        methodVisitor.visitInsn(Opcodes.POP);
+
+        methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(ArgumentSpec.class),
+                "extractArgumentList", Type.getMethodDescriptor(Type.getType(List.class),
+                        Type.getType(List.class), Type.getType(Map.class)),
+                false);
+
+        // Stack is function to call, argument list
+        // Unwrap the bound method
+        if (methodDescriptor.getMethodType() == MethodDescriptor.MethodType.VIRTUAL ||
+                methodDescriptor.getMethodType() == MethodDescriptor.MethodType.INTERFACE) {
+            methodVisitor.visitInsn(Opcodes.SWAP);
+            methodVisitor.visitInsn(Opcodes.DUP_X1);
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEVIRTUAL, Type.getInternalName(BoundPythonLikeFunction.class),
+                    "getInstance", Type.getMethodDescriptor(Type.getType(PythonLikeObject.class)),
+                    false);
+
+            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, methodDescriptor.getDeclaringClassInternalName());
+            methodVisitor.visitInsn(Opcodes.SWAP);
+        }
+
+        // Stack is method, boundedInstance?, default
+
+        // Read the parameters
+        for (int i = 0; i < descriptorParameterTypes.length; i++) {
+            methodVisitor.visitInsn(Opcodes.DUP);
+            methodVisitor.visitLdcInsn(i);
+            methodVisitor.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(List.class),
+                    "get", Type.getMethodDescriptor(Type.getType(Object.class), Type.INT_TYPE),
+                    true);
+            methodVisitor.visitTypeInsn(Opcodes.CHECKCAST, descriptorParameterTypes[i].getInternalName());
+            methodVisitor.visitInsn(Opcodes.SWAP);
+        }
+        methodVisitor.visitInsn(Opcodes.POP);
+
+        // Stack is method, boundedInstance?, arg0, arg1, ...
+
+        methodDescriptor.callMethod(methodVisitor);
+
+        // Stack is method, result
+    }
+}

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/function/CallMethodOpcode.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/function/CallMethodOpcode.java
@@ -22,7 +22,7 @@ public class CallMethodOpcode extends AbstractOpcode {
         if (functionType instanceof PythonKnownFunctionType) {
             PythonKnownFunctionType knownFunctionType = (PythonKnownFunctionType) functionType;
             PythonLikeType[] parameterTypes =
-                    new PythonLikeType[knownFunctionType.isStaticMethod() ? instruction.arg : instruction.arg + 1];
+                    new PythonLikeType[instruction.arg];
             for (int i = 0; i < parameterTypes.length; i++) {
                 parameterTypes[parameterTypes.length - i - 1] = stackMetadata.getTypeAtStackIndex(i);
             }

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/function/CallOpcode.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/function/CallOpcode.java
@@ -11,6 +11,7 @@ import org.optaplanner.jpyinterpreter.implementors.FunctionImplementor;
 import org.optaplanner.jpyinterpreter.opcodes.AbstractOpcode;
 import org.optaplanner.jpyinterpreter.types.BuiltinTypes;
 import org.optaplanner.jpyinterpreter.types.PythonKnownFunctionType;
+import org.optaplanner.jpyinterpreter.types.PythonLikeGenericType;
 import org.optaplanner.jpyinterpreter.types.PythonLikeType;
 
 public class CallOpcode extends AbstractOpcode {
@@ -22,6 +23,9 @@ public class CallOpcode extends AbstractOpcode {
     @Override
     protected StackMetadata getStackMetadataAfterInstruction(FunctionMetadata functionMetadata, StackMetadata stackMetadata) {
         PythonLikeType functionType = stackMetadata.getTypeAtStackIndex(instruction.arg + 1);
+        if (functionType instanceof PythonLikeGenericType) {
+            functionType = ((PythonLikeGenericType) functionType).getOrigin().getConstructorType().orElse(null);
+        }
         if (functionType instanceof PythonKnownFunctionType) {
             PythonKnownFunctionType knownFunctionType = (PythonKnownFunctionType) functionType;
             List<String> keywordArgumentNameList = stackMetadata.getCallKeywordNameList();
@@ -41,6 +45,9 @@ public class CallOpcode extends AbstractOpcode {
         }
 
         functionType = stackMetadata.getTypeAtStackIndex(instruction.arg);
+        if (functionType instanceof PythonLikeGenericType) {
+            functionType = ((PythonLikeGenericType) functionType).getOrigin().getConstructorType().orElse(null);
+        }
         if (functionType instanceof PythonKnownFunctionType) {
             PythonKnownFunctionType knownFunctionType = (PythonKnownFunctionType) functionType;
             List<String> keywordArgumentNameList = stackMetadata.getCallKeywordNameList();

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/function/LoadMethodOpcode.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/function/LoadMethodOpcode.java
@@ -35,7 +35,7 @@ public class LoadMethodOpcode extends AbstractOpcode {
                 .orElseGet(() -> stackMetadata.pop()
                         .push(ValueSourceInfo.of(this, PythonLikeFunction.getFunctionType(),
                                 stackMetadata.getValueSourcesUpToStackIndex(1)))
-                        .push(ValueSourceInfo.of(this, BuiltinTypes.BASE_TYPE,
+                        .push(ValueSourceInfo.of(this, BuiltinTypes.NULL_TYPE,
                                 stackMetadata.getValueSourcesUpToStackIndex(1)))); // either TOS or NULL
     }
 

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/function/SetCallKeywordNameTupleOpcode.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/function/SetCallKeywordNameTupleOpcode.java
@@ -1,10 +1,14 @@
 package org.optaplanner.jpyinterpreter.opcodes.function;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.optaplanner.jpyinterpreter.FunctionMetadata;
 import org.optaplanner.jpyinterpreter.PythonBytecodeInstruction;
 import org.optaplanner.jpyinterpreter.StackMetadata;
 import org.optaplanner.jpyinterpreter.implementors.FunctionImplementor;
 import org.optaplanner.jpyinterpreter.opcodes.AbstractOpcode;
+import org.optaplanner.jpyinterpreter.types.PythonString;
 
 public class SetCallKeywordNameTupleOpcode extends AbstractOpcode {
 
@@ -15,7 +19,9 @@ public class SetCallKeywordNameTupleOpcode extends AbstractOpcode {
     @Override
     public StackMetadata getStackMetadataAfterInstruction(FunctionMetadata functionMetadata,
             StackMetadata stackMetadata) {
-        return stackMetadata;
+        return stackMetadata.setCallKeywordNameList(
+                ((List<PythonString>) functionMetadata.pythonCompiledFunction.co_constants.get(instruction.arg))
+                        .stream().map(PythonString::getValue).collect(Collectors.toList()));
     }
 
     @Override

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/variable/LoadConstantOpcode.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/variable/LoadConstantOpcode.java
@@ -19,14 +19,14 @@ public class LoadConstantOpcode extends AbstractOpcode {
     @Override
     protected StackMetadata getStackMetadataAfterInstruction(FunctionMetadata functionMetadata, StackMetadata stackMetadata) {
         PythonLikeObject constant = functionMetadata.pythonCompiledFunction.co_constants.get(instruction.arg);
-        PythonLikeType constantType = constant.__getType();
+        PythonLikeType constantType = constant.__getGenericType();
         return stackMetadata.push(ValueSourceInfo.of(this, constantType));
     }
 
     @Override
     public void implement(FunctionMetadata functionMetadata, StackMetadata stackMetadata) {
         PythonLikeObject constant = functionMetadata.pythonCompiledFunction.co_constants.get(instruction.arg);
-        PythonLikeType constantType = constant.__getType();
+        PythonLikeType constantType = constant.__getGenericType();
 
         PythonConstantsImplementor.loadConstant(functionMetadata.methodVisitor, functionMetadata.className,
                 instruction.arg);

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/variable/LoadGlobalOpcode.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/opcodes/variable/LoadGlobalOpcode.java
@@ -43,17 +43,17 @@ public class LoadGlobalOpcode extends AbstractOpcode {
         if (pushNull) {
             if (global != null) {
                 return stackMetadata
-                        .push(ValueSourceInfo.of(this, BuiltinTypes.BASE_TYPE))
-                        .push(ValueSourceInfo.of(this, global.__getType()));
+                        .push(ValueSourceInfo.of(this, BuiltinTypes.NULL_TYPE))
+                        .push(ValueSourceInfo.of(this, global.__getGenericType()));
             } else {
                 return stackMetadata
-                        .push(ValueSourceInfo.of(this, BuiltinTypes.BASE_TYPE))
+                        .push(ValueSourceInfo.of(this, BuiltinTypes.NULL_TYPE))
                         .push(ValueSourceInfo.of(this, BuiltinTypes.BASE_TYPE));
             }
         } else {
             if (global != null) {
                 return stackMetadata
-                        .push(ValueSourceInfo.of(this, global.__getType()));
+                        .push(ValueSourceInfo.of(this, global.__getGenericType()));
             } else {
                 return stackMetadata
                         .push(ValueSourceInfo.of(this, BuiltinTypes.BASE_TYPE));
@@ -76,6 +76,6 @@ public class LoadGlobalOpcode extends AbstractOpcode {
             functionMetadata.methodVisitor.visitInsn(Opcodes.ACONST_NULL);
         }
         VariableImplementor.loadGlobalVariable(functionMetadata, stackMetadata, globalIndex,
-                (global != null) ? global.__getType() : BuiltinTypes.BASE_TYPE);
+                (global != null) ? global.__getGenericType() : BuiltinTypes.BASE_TYPE);
     }
 }

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/BuiltinTypes.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/BuiltinTypes.java
@@ -29,6 +29,8 @@ import org.optaplanner.jpyinterpreter.types.numeric.PythonNumber;
 import org.optaplanner.jpyinterpreter.types.wrappers.JavaMethodReference;
 
 public class BuiltinTypes {
+    public static final PythonLikeType NULL_TYPE =
+            new PythonLikeType("NULL", PythonLikeObject.class, Collections.emptyList());
     public static final PythonLikeType BASE_TYPE =
             new PythonLikeType("base-object", PythonLikeObject.class, Collections.emptyList());
     public static final PythonLikeType TYPE_TYPE = new PythonLikeType("type", PythonLikeType.class, List.of(BASE_TYPE));

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonKnownFunctionType.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonKnownFunctionType.java
@@ -27,6 +27,16 @@ public class PythonKnownFunctionType extends PythonLikeType {
         return overloadFunctionSignatureList.get(0).getMethodDescriptor().getMethodType() == MethodDescriptor.MethodType.CLASS;
     }
 
+    @Override
+    public PythonLikeType __getType() {
+        return BuiltinTypes.BASE_TYPE;
+    }
+
+    @Override
+    public PythonLikeType __getGenericType() {
+        return BuiltinTypes.BASE_TYPE;
+    }
+
     public Optional<PythonFunctionSignature> getDefaultFunctionSignature() {
         return overloadFunctionSignatureList.stream().findAny();
     }

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonKnownFunctionType.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonKnownFunctionType.java
@@ -48,4 +48,24 @@ public class PythonKnownFunctionType extends PythonLikeType {
         }
         return Optional.of(best);
     }
+
+    public Optional<PythonFunctionSignature> getFunctionForParameters(int positionalItemCount,
+            List<String> keywordNames,
+            List<PythonLikeType> callStackTypeList) {
+        List<PythonFunctionSignature> matchingOverloads = overloadFunctionSignatureList.stream()
+                .filter(signature -> signature.matchesParameters(positionalItemCount, keywordNames, callStackTypeList))
+                .collect(Collectors.toList());
+
+        if (matchingOverloads.isEmpty()) {
+            return Optional.empty();
+        }
+
+        PythonFunctionSignature best = matchingOverloads.get(0);
+        for (PythonFunctionSignature signature : matchingOverloads) {
+            if (signature.moreSpecificThan(best)) {
+                best = signature;
+            }
+        }
+        return Optional.of(best);
+    }
 }

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonLikeGenericType.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonLikeGenericType.java
@@ -2,6 +2,7 @@ package org.optaplanner.jpyinterpreter.types;
 
 import java.util.Optional;
 
+import org.optaplanner.jpyinterpreter.FieldDescriptor;
 import org.optaplanner.jpyinterpreter.PythonClassTranslator;
 
 public class PythonLikeGenericType extends PythonLikeType {
@@ -14,6 +15,22 @@ public class PythonLikeGenericType extends PythonLikeType {
 
     public PythonLikeType getOrigin() {
         return origin;
+    }
+
+    @Override
+    public Optional<FieldDescriptor> getInstanceFieldDescriptor(String fieldName) {
+        Optional<PythonKnownFunctionType> maybeMethodType = getMethodType(fieldName);
+        if (maybeMethodType.isEmpty()) {
+            return BuiltinTypes.TYPE_TYPE.getInstanceFieldDescriptor(fieldName);
+        } else {
+            PythonKnownFunctionType knownFunctionType = maybeMethodType.get();
+            FieldDescriptor out = new FieldDescriptor(fieldName,
+                    PythonClassTranslator.getJavaMethodName(fieldName),
+                    origin.getJavaTypeInternalName(),
+                    knownFunctionType.getJavaTypeDescriptor(),
+                    knownFunctionType, false);
+            return Optional.of(out);
+        }
     }
 
     @Override

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonLikeGenericType.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonLikeGenericType.java
@@ -1,5 +1,9 @@
 package org.optaplanner.jpyinterpreter.types;
 
+import java.util.Optional;
+
+import org.optaplanner.jpyinterpreter.PythonClassTranslator;
+
 public class PythonLikeGenericType extends PythonLikeType {
     final PythonLikeType origin;
 
@@ -10,6 +14,37 @@ public class PythonLikeGenericType extends PythonLikeType {
 
     public PythonLikeType getOrigin() {
         return origin;
+    }
+
+    @Override
+    public Optional<PythonKnownFunctionType> getMethodType(String methodName) {
+        Optional<PythonKnownFunctionType> originKnownFunctionType = origin.getMethodType(methodName);
+        if (originKnownFunctionType.isEmpty()) {
+            return originKnownFunctionType;
+        }
+
+        PythonKnownFunctionType knownFunctionType = originKnownFunctionType.get();
+        if (knownFunctionType.isStaticMethod() || knownFunctionType.isClassMethod()) {
+            return originKnownFunctionType;
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<PythonClassTranslator.PythonMethodKind> getMethodKind(String methodName) {
+        Optional<PythonClassTranslator.PythonMethodKind> originMethodKind = origin.getMethodKind(methodName);
+        if (originMethodKind.isEmpty()) {
+            return originMethodKind;
+        }
+
+        switch (originMethodKind.get()) {
+            case STATIC_METHOD:
+            case CLASS_METHOD:
+                return originMethodKind;
+            default:
+                return Optional.empty();
+        }
     }
 
     @Override

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonLikeType.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonLikeType.java
@@ -534,6 +534,19 @@ public class PythonLikeType implements PythonLikeObject,
                 BuiltinTypes.asmClassLoader);
     }
 
+    /**
+     * Return the Java class corresponding to this type, if it exists. Returns {@code defaultValue} otherwise.
+     *
+     * @param defaultValue the value to return
+     */
+    public Class<?> getJavaClassOrDefault(Class<?> defaultValue) {
+        try {
+            return getJavaClass();
+        } catch (ClassNotFoundException e) {
+            return defaultValue;
+        }
+    }
+
     public List<PythonLikeType> getParentList() {
         return PARENT_TYPES;
     }

--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonLikeType.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/PythonLikeType.java
@@ -511,6 +511,11 @@ public class PythonLikeType implements PythonLikeObject,
 
     @Override
     public PythonLikeType __getType() {
+        return BuiltinTypes.TYPE_TYPE;
+    }
+
+    @Override
+    public PythonLikeType __getGenericType() {
         return new PythonLikeGenericType(this);
     }
 

--- a/jpyinterpreter/tests/datetime/test_timedelta.py
+++ b/jpyinterpreter/tests/datetime/test_timedelta.py
@@ -294,3 +294,17 @@ def test_repr():
     verifier.verify(timedelta(seconds=10, microseconds=123456),
                     expected_result='datetime.timedelta(seconds=10, microseconds=123456)')
     verifier.verify(timedelta(weeks=1, hours=16, minutes=30), expected_result='datetime.timedelta(days=7, seconds=59400)')
+
+
+def test_between_0_and_30_minutes():
+    def function(a: timedelta) -> bool:
+        return timedelta(minutes=0) <= a <= timedelta(minutes=30)
+
+    verifier = verifier_for(function)
+
+    verifier.verify(timedelta(minutes=0), expected_result=True)
+    verifier.verify(timedelta(minutes=15), expected_result=True)
+    verifier.verify(timedelta(minutes=30), expected_result=True)
+
+    verifier.verify(timedelta(minutes=-15), expected_result=False)
+    verifier.verify(timedelta(minutes=45), expected_result=False)

--- a/jpyinterpreter/tests/test_dict.py
+++ b/jpyinterpreter/tests/test_dict.py
@@ -196,7 +196,6 @@ def test_get():
 
 def test_items():
     def items(my_dict: dict) -> list:
-        print(my_dict)
         return list(my_dict.items())
 
     def items_with_modification(my_dict: dict) -> list:


### PR DESCRIPTION
This improves performance of school-timetabling by roughly 50% (24,000 -> 38,000 in 3.9/3.10, 20,000 -> 36,000 in 3.11).

Optimize calls to known functions (virtual, class, static).

- Modify StackMetadata so it internal fields are private for better
  encapsulation.

- Add callKeywordNameList to StackMetadata. This is used for
  Python 3.11 and above function calls, which store the keyword
  arguments into a special local variable. It used by us to
  specialize a generic function call into a known function call.

- Fix PythonCompiledFunction's getArgumentSpecMapper() to set
  type of the return value and parameters, which are now used
  by PythonFunctionSignature for typecasting.

- Fix DefaultArgumentImplementor handling of positional arguments,
  which incorrectly assumed argumentNameToIndex map values are
  all positional arguments (they may be keyword only).

- Add ArgumentSpec field to PythonFunctionSignature, which makes it
  easier to determine the correct ordering of arguments on the
  stack.

- How known function calls work is as follows:
    1. Store arguments on the stack into their corresponding temporary local
       variables
    2. If the function a virtual or class method, typecast self /
       find the type to pass to the function
    3. Load arguments from their corresponding temporary local variables
       and typecast them.
    4. Call the method

  this code is a bit simpler and easier to understand then the previous
  code, which needed to do complex argument index calculations to
  account for keyword only arguments etc.

- ArgumentSpec is now used to determine if a function signature call
  matches a particular overload.

- Fix a bug in ArgumentSpec where addNullableArgument and
  addNullablePositionalOnlyArgument accidentally used the
  KEYWORD_ONLY argument kind.

- Remove a debug print statement that was in a test

- PythonGenericType is a type of a particular type, and thus has access
to that type's static and class methods (which can be accessed without
an instance). Overriden getInstanceFieldDescriptor() in PythonGenericType
to return a fake FieldDescriptor that describe the method object which
will be on the type. It is fake in the sense the Java object does
NOT have a corresponding field for it, but it exists in the Python
attributes dictionary.

- Add the missing Type -> Constructor conversion in the Python 3.11
CALL opcode and implementor (which allows constructors to be
specialized).

- Add a NULL type, so it is easier to see where NULL are on the stack
when debugging.

- PythonKnownFunctionType returns BASE_OBJECT for __getType and
__getGenericType, since accessing it via attribute returns an
object, not a type.
