### PR TITLE
optapy#143: Fix truncating floats to 32-bits in conversion

### DIFF
--- a/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/numeric/PythonFloat.java
+++ b/jpyinterpreter/src/main/java/org/optaplanner/jpyinterpreter/types/numeric/PythonFloat.java
@@ -179,7 +179,7 @@ public class PythonFloat extends AbstractPythonLikeObject implements PythonNumbe
     public PythonLikeTuple asFraction() {
         final BigInteger FIVE = BigInteger.valueOf(5L);
 
-        BigDecimal bigDecimal = BigDecimal.valueOf(value);
+        BigDecimal bigDecimal = new BigDecimal(value);
         BigInteger numerator = bigDecimal.movePointRight(bigDecimal.scale()).toBigIntegerExact();
         BigInteger denominator;
         if (bigDecimal.scale() < 0) {
@@ -363,7 +363,7 @@ public class PythonFloat extends AbstractPythonLikeObject implements PythonNumbe
         if (other.value.equals(BigInteger.ZERO)) {
             throw new ZeroDivisionError("float division");
         }
-        return new PythonFloat(BigDecimal.valueOf(value)
+        return new PythonFloat(new BigDecimal(value)
                 .divideToIntegralValue(new BigDecimal(other.value))
                 .doubleValue());
     }
@@ -379,7 +379,7 @@ public class PythonFloat extends AbstractPythonLikeObject implements PythonNumbe
         if (other.value.equals(BigInteger.ZERO)) {
             throw new ZeroDivisionError("float division");
         }
-        return new PythonFloat(BigDecimal.valueOf(value)
+        return new PythonFloat(new BigDecimal(value)
                 .divide(new BigDecimal(other.value), RoundingMode.CEILING)
                 .doubleValue());
     }
@@ -521,7 +521,7 @@ public class PythonFloat extends AbstractPythonLikeObject implements PythonNumbe
             return round();
         }
 
-        BigDecimal asDecimal = BigDecimal.valueOf(value);
+        BigDecimal asDecimal = new BigDecimal(value);
         return new PythonFloat(
                 asDecimal.setScale(digitsAfterDecimal.value.intValueExact(), RoundingMode.HALF_EVEN).doubleValue());
     }
@@ -713,7 +713,7 @@ public class PythonFloat extends AbstractPythonLikeObject implements PythonNumbe
             case LOCALE_SENSITIVE:
             case LOWERCASE_GENERAL:
             case UPPERCASE_GENERAL:
-                BigDecimal asBigDecimal = BigDecimal.valueOf(value);
+                BigDecimal asBigDecimal = new BigDecimal(value);
                 // total digits - digits to the right of the decimal point
                 int exponent;
                 if (asBigDecimal.precision() == asBigDecimal.scale() + 1) {

--- a/jpyinterpreter/src/main/python/python_to_java_bytecode_translator.py
+++ b/jpyinterpreter/src/main/python/python_to_java_bytecode_translator.py
@@ -6,7 +6,7 @@ import sys
 import abc
 from typing import Union
 
-from jpype import JInt, JLong, JFloat, JBoolean, JProxy, JClass, JArray
+from jpype import JInt, JLong, JDouble, JBoolean, JProxy, JClass, JArray
 
 MINIMUM_SUPPORTED_PYTHON_VERSION = (3, 9)
 MAXIMUM_SUPPORTED_PYTHON_VERSION = (3, 11)
@@ -347,7 +347,7 @@ def convert_to_java_python_like_object(value, instance_map=None):
         put_in_instance_map(instance_map, value, out)
         return out
     elif isinstance(value, float):
-        out = PythonFloat.valueOf(JFloat(value))
+        out = PythonFloat.valueOf(JDouble(value))
         put_in_instance_map(instance_map, value, out)
         return out
     elif isinstance(value, complex):

--- a/jpyinterpreter/tests/test_float.py
+++ b/jpyinterpreter/tests/test_float.py
@@ -4,6 +4,15 @@ MAX_LONG = 0xFFFF_FFFF_FFFF_FFFF
 MIN_LONG = -MAX_LONG
 
 
+def test_use_64_bits():
+    def identity(x: float) -> float:
+        return x
+
+    identity_verifier = verifier_for(identity)
+
+    identity_verifier.verify(2345678.2345678, expected_result=2345678.2345678)
+
+
 def test_add():
     def int_add(a: float, b: int) -> float:
         return a + b


### PR DESCRIPTION
JFloat was used instead of JDouble when converting a CPython float (which is 64-bits) to a jpyinterpreter float, causing the value to be incorrectly truncated.

Fixing this issue exposed another issue: BigDecimal.valueOf(double) returns the shortest BigDecimal that has the same double value, not the canonical double value. This means for `1.055`, which is actually stored as `1.0549999....`, when rounded to 2 decimal places, returns `1.06` (incorrect) instead of `1.05` (correct). This is fixed by using `new BigDecimal(double)` instead, which uses the canonical double value.