### PR TITLE
optapy#150: Fix nullable variables and deleted attributes

### DIFF
--- a/jpyinterpreter/tests/test_classes.py
+++ b/jpyinterpreter/tests/test_classes.py
@@ -24,6 +24,29 @@ def test_create_instance():
     verifier.verify(3, expected_result=A(3))
 
 
+def test_deleted_field():
+    class A:
+        value: int
+
+        def __init__(self, value):
+            self.value = value
+
+        def my_method(self, param):
+            return self.value + param
+
+    def my_method(x: A, y: int) -> int:
+        return x.my_method(y)
+
+    verifier = verifier_for(my_method)
+
+    a = A(1)
+    verifier.verify(a, 1, expected_result=2)
+
+    del a.value
+
+    verifier.verify(a, 1, expected_error=AttributeError)
+
+
 def test_virtual_method():
     class A:
         value: int

--- a/tests/test_custom_shadow_variables.py
+++ b/tests/test_custom_shadow_variables.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import optapy
 import optapy.constraint
 import optapy.score
@@ -33,8 +34,8 @@ def test_custom_shadow_variable():
 
     @optapy.planning_entity
     class MyPlanningEntity:
-        value: int
-        value_squared: int
+        value: Optional[int]
+        value_squared: Optional[int]
 
         def __init__(self):
             self.value = None
@@ -144,9 +145,9 @@ def test_custom_shadow_variable_with_variable_listener_ref():
 
     @optapy.planning_entity
     class MyPlanningEntity:
-        value: int
-        value_squared: int
-        twice_value: int
+        value: Optional[int]
+        value_squared: Optional[int]
+        twice_value: Optional[int]
 
         def __init__(self):
             self.value = None


### PR DESCRIPTION
The old generated wrapper for the setters did not consider that valueAsPythonLikeObject can be null, and thus can potentially pass null to the delegated setter. For simple getters/setters that don't modify the parameter, it "deletes" the attribute (since jpyinterpreter use null to mean "missing attribute"). Thus, we need to change the null to None if None is assignable to the setter's parameter (in the case None is not assignable to the parameter, we still pass null, since planning variable getters/setters should be simple).

This was worsen by the fact `jpyinterpreter` assumes all known attributes of a type will always exist, and thus cause null to propagate through code instead of raising an AttributeError. `jpyinterpreter` now checks if the field is null, and if so, throw an AttributeError.

The test for custom shadow variables had typing errors (in particular, the shadow variable and the planning variable are nullable int, but was typed as int, meaning a TypeError occurs when you try to assign None to them. I changed their types to Optional[int], which allows None to be assigned to them.