### PR TITLE
optapy#154: Update all attributes of all wrapped objects after clone

### DIFF
--- a/optapy-core/src/main/java/org/optaplanner/optapy/PythonWrapperGenerator.java
+++ b/optapy-core/src/main/java/org/optaplanner/optapy/PythonWrapperGenerator.java
@@ -1466,9 +1466,7 @@ public class PythonWrapperGenerator {
             methodCreator.setModifiers(Modifier.PUBLIC);
             methodCreator.invokeSpecialMethod(MethodDescriptor.ofConstructor(parentClass, PythonLikeType.class),
                     methodCreator.getThis(),
-                    methodCreator.readStaticField(FieldDescriptor.of(classCreator.getClassName(),
-                            "$TYPE",
-                            PythonLikeType.class)));
+                    methodCreator.getMethodParam(0));
             methodCreator.returnValue(methodCreator.getThis());
         } else {
             // Entity(OpaquePythonReference) constructor, for subclasses


### PR DESCRIPTION
Additionally, fix the type of problem facts and planning entities that are subclassed.

Previously, some attributes escaped being updated when they are not accessible from the planning solution class (ex: inside the value range of a planning entity). To account for this, after the entire solution is cloned, we go through the list of wrapped objects and update them from their corresponding object. This need to be done after everything is cloned, so the reference map contains every discovered planning entity and problem fact (if done in the planning entity setFields, multiple instances of the same object may be constructed, potentially causing an infinite loop in vehicle-routing).